### PR TITLE
Make sbatch submission machine-drivable and shell-safe (+ cluster resource inventory)

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Lint
         run: uv run ruff check .
 
+      - name: Unit tests
+        run: uv run pytest tests/ -q
+
       # Runs the full quick_test workflow — generate training data with
       # ssm-simulators, then train a network with LANfactory (MLflow-tracked).
       # This guards the pipeline, its configs, and its integration with the two

--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ LAN_pipeline_minimal/
 │   ├── quick_test/         # Fast testing configs (~1-2 min)
 │   │   ├── data_generation.yaml
 │   │   └── network_training.yaml
+│   ├── cluster/            # Cluster resource inventories
+│   │   └── oscar.yaml      # Condos, limits, per-job-kind defaults
 │   ├── legacy/             # Archived old workflow configs
 │   └── README.md           # Config documentation
 ├── sbatch_scripts/
 │   ├── gen_sbatch.py       # Main orchestrator script
 │   ├── sample_*.sh         # Example generated SBATCH scripts
 │   └── legacy/             # Archived old sbatch scripts
+├── tests/                  # pytest suite for gen_sbatch
 ├── local_test_run.sh       # Local end-to-end test script
 ├── using_mlflow.md         # MLflow integration guide
 └── pyproject.toml          # Dependencies (from GitHub main branches)
@@ -78,7 +81,8 @@ uv run python sbatch_scripts/gen_sbatch.py generate \
     --config-path configs/examples/data_generation.yaml \
     --output-path /path/to/output \
     --n-jobs-in-array 10 \
-    --partition gpu
+    --n-files 20 \
+    --cluster-config configs/cluster/oscar.yaml
 
 # Or run directly (local)
 uv run generate \
@@ -86,6 +90,31 @@ uv run generate \
     --output ./data \
     --n-files 5
 ```
+
+**Where things land, and what comes back.** The generated script and the
+SLURM `.out`/`.err` files are written to `<output-path>/runs/`, timestamped —
+repeated invocations never overwrite each other. Each invocation prints
+exactly one JSON line on stdout (all logging goes to stderr, so this holds at
+any `--log-level`):
+
+```json
+{"command": "generate --config-path ...", "job_id": 9876543,
+ "mlflow_experiment_id": "42", "mlflow_run_id": null,
+ "sbatch_script": "/path/to/output/runs/20260809T101500_ddm_generate_sbatch.sh",
+ "output_path": "/path/to/output", "account": "carney-frankmj-condo",
+ "partition": "batch"}
+```
+
+That line is the interface for scripted use — `jq -r .job_id` to poll with
+`sacct`, `jq -r .mlflow_experiment_id` to chain into training. A failed
+submission exits non-zero with `"job_id": null`. `--script-only` writes the
+script and prints the same line without submitting, and creates no MLflow
+experiment or run.
+
+**Cluster resources.** `--cluster-config` reads per-job-kind defaults
+(account, partition, cores, memory, GPUs, wall time) from a cluster
+inventory; see `configs/README.md`. Precedence is built-in fallbacks <
+cluster config < explicit flags, so any flag below still wins.
 
 ### Network Training
 
@@ -95,8 +124,8 @@ uv run python sbatch_scripts/gen_sbatch.py jaxtrain \
     --config-path configs/examples/network_training_lan.yaml \
     --output-path /path/to/networks \
     --training-data-folder /path/to/data \
-    --data-generation-experiment-id <exp-id>  # Links to data gen for lineage
-    --partition gpu
+    --data-generation-experiment-id <exp-id> \
+    --cluster-config configs/cluster/oscar.yaml
 
 # Or run directly (local)
 uv run jaxtrain \

--- a/configs/README.md
+++ b/configs/README.md
@@ -8,6 +8,7 @@ This folder contains YAML configuration files for the LAN pipeline.
 configs/
 ├── examples/           # Production-ready example configs
 ├── quick_test/         # Fast testing configs (~1-2 min runtime)
+├── cluster/            # Cluster resource inventories (oscar.yaml)
 └── legacy/             # Archived bash workflow configs (deprecated)
 ```
 
@@ -73,6 +74,40 @@ uv run python sbatch_scripts/gen_sbatch.py generate \
     --config-path configs/examples/data_generation.yaml \
     --output-path /shared/data
 ```
+
+## Cluster Configs (`cluster/oscar.yaml`)
+
+A record of *what we can schedule where*: the condos we hold, their partitions
+and limits, which job kinds each suits, and the sbatch defaults to use for
+each. Pass it with `--cluster-config` so submissions are made with awareness
+of the actual cluster rather than hardcoded guesses:
+
+```bash
+uv run python sbatch_scripts/gen_sbatch.py generate \
+    --config-path configs/examples/data_generation.yaml \
+    --output-path /shared/data \
+    --cluster-config configs/cluster/oscar.yaml
+```
+
+| Section | Purpose |
+|---------|---------|
+| `condos` | Per-account record: `partitions`, `nodes`, `limits`, `suited_for`, `verified` |
+| `job_defaults` | Job kind (`generate`/`jaxtrain`/`torchtrain`) → `account`, `partition`, `cores`, `mem`, `num_gpus`, `time`, optional `modules` |
+| `modules` | Modules loaded at the top of every generated script |
+
+**Precedence:** built-in fallbacks < `job_defaults.<job kind>` < explicit CLI
+flags. For `modules`, a per-job-kind list overrides the top-level one, and an
+explicit empty list (`modules: []`) means "load no modules" — distinct from
+omitting the key, which keeps the defaults.
+
+**Quote your wall times.** YAML 1.1 reads an unquoted `time: 12:00:00` as the
+integer 43200, which SLURM would interpret as 43200 *minutes*. Write
+`time: "12:00:00"`. `gen_sbatch` rejects the unquoted form with an explicit
+error rather than submitting a 30-day request.
+
+Entries carry `verified: false` until they are seeded from a live cluster
+snapshot (`sacctmgr show associations`, `sinfo`, `scontrol show partition`) —
+do not add condos or limits from memory.
 
 ## Legacy Configs
 

--- a/configs/cluster/oscar.yaml
+++ b/configs/cluster/oscar.yaml
@@ -1,0 +1,64 @@
+# Oscar (Brown CCV) cluster resource inventory.
+#
+# PURPOSE
+#   The record of *what we can schedule where*: which condos we hold, their
+#   partitions and limits, and which job kinds they suit. sbatch_scripts/
+#   gen_sbatch.py reads the job_defaults section via --cluster-config, so
+#   submissions are made with full awareness of what's around instead of
+#   hardcoded guesses. Explicit CLI flags always override these defaults.
+#
+# PROVENANCE
+#   Structure is authoritative; VALUES BELOW ARE UNVERIFIED PRIOR ART and must
+#   be refreshed from the cluster itself via HSSMSpine
+#   scripts/cluster/oscar_inventory.sh (sacctmgr show associations, sinfo,
+#   scontrol show partition). Entries carry `verified: false` until that
+#   snapshot lands. Do not add condos or limits from memory.
+#
+# SCHEMA
+#   condos:            per-condo record (account name -> details)
+#     partitions:      partition names usable under this account
+#     nodes:           {cores, mem, gpus: {type, count}} per node class
+#     limits:          {max_walltime, max_cores, max_concurrent_jobs}
+#     suited_for:      job kinds that belong here (generate | jaxtrain | torchtrain)
+#     verified:        false until seeded from an oscar_inventory.sh snapshot
+#   job_defaults:      job kind -> sbatch defaults (account, partition,
+#                      cores, mem, num_gpus, time)
+#   modules:           modules loaded at the top of every generated script
+
+condos:
+  carney-frankmj-condo:
+    partitions: [batch, gpu]
+    nodes: {}          # seed from oscar_inventory.sh
+    limits: {}         # seed from oscar_inventory.sh
+    suited_for: [generate]   # CPU-heavy array simulation
+    verified: false
+
+job_defaults:
+  # Datagen: CPU-bound array jobs, many small workers.
+  generate:
+    account: carney-frankmj-condo
+    partition: batch
+    cores: 1
+    mem: 16G
+    num_gpus: 0
+    time: "04:00:00"
+  # Training: single jobs; GPU placement to be confirmed by the inventory
+  # snapshot (which GPU partition/condo we can actually use).
+  jaxtrain:
+    account: carney-frankmj-condo
+    partition: batch
+    cores: 2
+    mem: 32G
+    num_gpus: 0
+    time: "12:00:00"
+  torchtrain:
+    account: carney-frankmj-condo
+    partition: batch
+    cores: 2
+    mem: 32G
+    num_gpus: 0
+    time: "12:00:00"
+
+modules:
+  - python
+  - gcc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,12 @@ ssm-simulators = { git = "https://github.com/lnccbrown/ssm-simulators", branch =
 
 [dependency-groups]
 dev = [
+    "pytest>=8.3.1",
     # <0.16: ruff 0.16 flags pre-existing code repo-wide (B008 on the standard
     # typer.Option idiom, ...). Same pin as ssm-simulators and LANfactory;
     # migrate the ecosystem to 0.16 deliberately, in one dedicated pass.
     "ruff>=0.15.1,<0.16",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/sbatch_scripts/gen_sbatch.py
+++ b/sbatch_scripts/gen_sbatch.py
@@ -122,6 +122,18 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 _SLURM_TIME_RE = re.compile(r"^(\d+|\d+:\d{2}|\d+:\d{2}:\d{2}|\d+-\d+(:\d{2}){0,2})$")
 
 
+def safe_name(value) -> str:
+    """Reduce a config-supplied name to something safe in a path or job name.
+
+    The model name comes from a user-supplied pipeline YAML and ends up in the
+    generated script's filename, the SLURM job name, and the log filenames.
+    Path separators and ``..`` would let it escape the ``runs/`` directory, and
+    SLURM job names should not contain whitespace or shell metacharacters.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", str(value)).lstrip(".")
+    return cleaned or "unnamed"
+
+
 def absolutize_tracking_uri(uri: str) -> str:
     """Make a relative sqlite MLflow URI absolute.
 
@@ -230,23 +242,51 @@ def resolve_resources(
 def validate_resources(resolved: dict, source) -> None:
     """Reject resource values SLURM would silently misread.
 
-    Chiefly YAML 1.1 sexagesimal: an unquoted ``time: 12:00:00`` loads as the
-    integer 43200, which SLURM reads as 43200 *minutes* — a 60x wall-time
-    request. Fail loudly at generation time instead.
+    Wall times must be **quoted strings** in YAML. Any bare number is
+    ambiguous once PyYAML has parsed it, because YAML 1.1 reads colon-separated
+    digits as sexagesimal: ``12:00:00`` and ``0:30`` load as the integers 43200
+    and 30, indistinguishable from someone writing 43200 or 30 minutes
+    directly. SLURM reads a bare integer as minutes, so an unquoted
+    ``time: 12:00:00`` silently becomes a 30-day request (43200 minutes) and
+    ``time: 4:00``, meant as 4 minutes, becomes 4 hours.
+
+    Rather than guess which reading was intended, require the quoted form.
     """
     time_value = resolved.get("time")
-    if isinstance(time_value, int) or not _SLURM_TIME_RE.match(str(time_value)):
-        hint = ""
-        if isinstance(time_value, int):
-            hours, remainder = divmod(time_value, 3600)
-            minutes, seconds = divmod(remainder, 60)
-            hint = (
-                f" YAML parsed it as the integer {time_value}; quote it "
-                f'("{hours:02d}:{minutes:02d}:{seconds:02d}") in {source}.'
-            )
+    if isinstance(time_value, int):
+        hours, remainder = divmod(time_value, 3600)
+        minutes, seconds = divmod(remainder, 60)
+        raise typer.BadParameter(
+            f"Wall time in {source} must be a quoted string; YAML parsed it as "
+            f"the integer {time_value}. If you meant {time_value} minutes write "
+            f'time: "{time_value}"; if you meant '
+            f"{hours:02d}:{minutes:02d}:{seconds:02d} write "
+            f'time: "{hours:02d}:{minutes:02d}:{seconds:02d}". '
+            "(YAML 1.1 reads 12:00:00 as the integer 43200, which SLURM would "
+            "take as 43200 minutes.)"
+        )
+    if not _SLURM_TIME_RE.match(str(time_value)):
         raise typer.BadParameter(
             f"Invalid SLURM wall time {time_value!r}. Expected forms: "
-            f"MM, HH:MM, HH:MM:SS, D-HH, D-HH:MM, D-HH:MM:SS.{hint}"
+            "MM, MM:SS, HH:MM:SS, D-HH, D-HH:MM, D-HH:MM:SS."
+        )
+
+
+def validate_log_path(path) -> None:
+    """Reject SLURM log paths SLURM cannot express.
+
+    The path is interpolated into ``#SBATCH --output=`` / ``--error=``, whose
+    value SLURM takes literally to the end of the line without dequoting — so
+    there is no quoting that makes whitespace work. Fail at generation time
+    with the reason rather than at submission with a parse error.
+    """
+    text = str(path)
+    if any(character.isspace() for character in text):
+        raise typer.BadParameter(
+            f"Output path {text!r} contains whitespace. SLURM writes job logs "
+            "via #SBATCH --output=/--error=, which it reads literally (no "
+            "quoting or escaping is honored), so a path with spaces cannot be "
+            "expressed. Use a path without whitespace."
         )
 
 
@@ -277,10 +317,12 @@ def create_sbatch_script(
         mem=mem,
         job_name=job_name,
         time=time,
-        # SLURM splits #SBATCH directive lines on whitespace; quoting keeps a
-        # path with spaces in one piece (a no-op for ordinary paths).
-        output=shlex.quote(str(output)),
-        error=shlex.quote(str(error)),
+        # Deliberately NOT quoted: SLURM reads a #SBATCH directive's value
+        # literally and does not dequote it, so quotes would end up in the
+        # filename. Paths containing whitespace are rejected upfront instead
+        # (validate_log_path).
+        output=str(output),
+        error=str(error),
         command=command,
         n_jobs_in_array=n_jobs_in_array,
         env_vars=env_vars,
@@ -600,12 +642,13 @@ def handle_job(
     command = create_command(command_name, **params)
     logger.info(f"Generated command: {command}")
     basic_config = get_basic_config_from_yaml(params["config-path"])
-    job_name = f"{basic_config['MODEL']}_{command_name}_sbatch"
+    job_name = f"{safe_name(basic_config['MODEL'])}_{command_name}_sbatch"
 
     # Scripts and SLURM logs live under <output_path>/runs/, timestamped —
     # repeated invocations never overwrite each other (previously the script
     # landed in CWD under a fixed name).
     runs_dir = target / "runs"
+    validate_log_path(runs_dir)
     runs_dir.mkdir(exist_ok=True, parents=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
     script = runs_dir / f"{timestamp}_{job_name}.sh"
@@ -680,6 +723,9 @@ def generate(
     ),
     cluster_config: Path = typer.Option(
         None,
+        exists=True,
+        dir_okay=False,
+        readable=True,
         help="Cluster inventory YAML (e.g. configs/cluster/oscar.yaml); its "
         "job_defaults section supplies account/partition/resources for this "
         "job kind. Explicit flags below override it.",
@@ -752,6 +798,9 @@ def train_command(command_name: str):
         ),
         cluster_config: Path = typer.Option(
             None,
+            exists=True,
+            dir_okay=False,
+            readable=True,
             help="Cluster inventory YAML (e.g. configs/cluster/oscar.yaml); its "
             "job_defaults section supplies account/partition/resources for "
             "this job kind. Explicit flags below override it.",

--- a/sbatch_scripts/gen_sbatch.py
+++ b/sbatch_scripts/gen_sbatch.py
@@ -8,8 +8,12 @@ MLflow Integration:
 - For training: The orchestrator creates a parent run and passes --mlflow-run-id to continue logging
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
+import json
 import logging
+import re
+import shlex
 import subprocess
 import typer
 import yaml
@@ -37,8 +41,12 @@ SBATCH_TEMPLATE = """#!/bin/bash
 #SBATCH --error={error}
 #SBATCH --array=1-{n_jobs_in_array}
 
-module load python
-module load gcc
+{module_loads}
+
+# The uv project is resolved from the working directory, and SLURM starts the
+# job in whatever directory sbatch was invoked from — $HOME for a driver that
+# submits over ssh. Pin it to the checkout that generated this script.
+cd {project_root} || exit 1
 
 # MLflow environment variables
 {env_vars}
@@ -65,11 +73,181 @@ python -m uv run {command}
 # Braces are doubled because this string is consumed by str.format().
 
 
-def create_command(command_name: str, **params: dict):
-    """Create CLI command string from parameters."""
-    command = f"{command_name} "
-    command += " ".join([f"--{key} {value}" for key, value in params.items()])
-    return command
+# Values that must stay shell-expandable inside the job, because SLURM
+# substitutes per-task. Only the variables in ALLOWED_SHELL_VARS expand; every
+# other character is quoted literally (see quote_param_value).
+SHELL_EXPANDED_PARAMS = frozenset({"mlflow-run-name"})
+
+# The only shell expansions allowed inside SHELL_EXPANDED_PARAMS values.
+ALLOWED_SHELL_VARS = ("SLURM_ARRAY_TASK_ID", "SLURM_ARRAY_JOB_ID", "SLURM_JOB_ID")
+_ALLOWED_VAR_RE = re.compile(r"\$(?:" + "|".join(ALLOWED_SHELL_VARS) + r")\b")
+
+# Historical CLI defaults per job kind, used when no --cluster-config is given.
+# A cluster config's job_defaults section overrides these; explicit CLI flags
+# override both.
+JOB_KIND_FALLBACKS = {
+    "generate": {
+        "account": "default",
+        "partition": "batch",
+        "num_gpus": 0,
+        "cores": 1,
+        "mem": "16G",
+        "time": "00:30:00",
+    },
+    "jaxtrain": {
+        "account": "default",
+        "partition": "batch",
+        "num_gpus": 0,
+        "cores": 1,
+        "mem": "16G",
+        "time": "00:30:00",
+    },
+    "torchtrain": {
+        "account": "default",
+        "partition": "batch",
+        "num_gpus": 0,
+        "cores": 1,
+        "mem": "16G",
+        "time": "00:30:00",
+    },
+}
+
+DEFAULT_MODULES = ["python", "gcc"]
+
+# The checkout this script lives in — baked into generated scripts so the job
+# runs against the right uv project regardless of the submission directory.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+# SLURM wall-time syntax accepted for the `time` resource.
+_SLURM_TIME_RE = re.compile(r"^(\d+|\d+:\d{2}|\d+:\d{2}:\d{2}|\d+-\d+(:\d{2}){0,2})$")
+
+
+def absolutize_tracking_uri(uri: str) -> str:
+    """Make a relative sqlite MLflow URI absolute.
+
+    ``sqlite:///mlflow.db`` resolves against the *current* working directory,
+    which differs between the submitting process and each compute node's job
+    (SLURM starts jobs in the submission directory). Left relative, workers
+    silently create their own database and the experiment id reported in the
+    JSON contract points at a file nothing ever wrote to.
+    """
+    prefix = "sqlite:///"
+    if not uri.startswith(prefix):
+        return uri  # server URIs and already-absolute sqlite:////... are fine
+    path_part = uri[len(prefix) :]
+    if path_part.startswith("/"):
+        return uri
+    return f"{prefix}{Path(path_part).resolve()}"
+
+
+def quote_param_value(key: str, value) -> str:
+    """Quote a CLI parameter value for embedding in the sbatch script.
+
+    Default: shlex.quote, so the value is one inert literal argument.
+
+    For SHELL_EXPANDED_PARAMS the value must keep expanding SLURM's per-task
+    variables, so it is split into segments: occurrences of ALLOWED_SHELL_VARS
+    are emitted bare (inside double quotes) and *everything else* is
+    shlex.quoted. Adjacent quoted segments concatenate into one shell word, so
+    e.g. `ddm-worker-$SLURM_ARRAY_TASK_ID` becomes
+
+        'ddm-worker-'"$SLURM_ARRAY_TASK_ID"
+
+    Blanket double-quoting would be wrong here: the model name comes from a
+    user-supplied pipeline YAML, and inside double quotes bash still executes
+    backticks and `$(...)` and expands every other `$VAR` — so a model named
+    ``ddm`hostname` `` would run a command on the compute node.
+    """
+    text = str(value)
+    if key not in SHELL_EXPANDED_PARAMS:
+        return shlex.quote(text)
+
+    segments = []
+    position = 0
+    for match in _ALLOWED_VAR_RE.finditer(text):
+        if match.start() > position:
+            segments.append(shlex.quote(text[position : match.start()]))
+        segments.append(f'"{match.group(0)}"')
+        position = match.end()
+    if position < len(text):
+        segments.append(shlex.quote(text[position:]))
+    return "".join(segments) if segments else "''"
+
+
+def create_command(command_name: str, **params) -> str:
+    """Create CLI command string from parameters, shell-quoted."""
+    parts = [command_name]
+    parts += [
+        f"--{key} {quote_param_value(key, value)}" for key, value in params.items()
+    ]
+    return " ".join(parts)
+
+
+def resolve_resources(
+    command_name: str,
+    cluster_config_path: Path | None,
+    cli_values: dict,
+    logger=None,
+) -> dict:
+    """Resolve job resources: builtin fallbacks < cluster config < CLI flags.
+
+    Within the cluster config, a per-job-kind ``modules`` list beats the
+    top-level one (specific beats generic), and an explicitly empty list means
+    "load no modules" — distinct from the key being absent, which means "use
+    the defaults".
+
+    cli_values holds only flags the user actually passed (None = not passed).
+    """
+    resolved = dict(JOB_KIND_FALLBACKS[command_name])
+    modules = list(DEFAULT_MODULES)
+
+    if cluster_config_path is not None:
+        with open(cluster_config_path, "rb") as f:
+            cluster_config = yaml.safe_load(f) or {}
+        job_defaults = (cluster_config.get("job_defaults") or {}).get(command_name, {})
+
+        known = set(resolved) | {"modules"}
+        unknown = set(job_defaults) - known
+        if unknown and logger is not None:
+            logger.warning(
+                f"Ignoring unknown job_defaults keys for {command_name!r} in "
+                f"{cluster_config_path}: {sorted(unknown)}"
+            )
+        resolved.update({k: v for k, v in job_defaults.items() if k in resolved})
+
+        # Presence, not truthiness: `modules: []` disables module loading.
+        if "modules" in cluster_config:
+            modules = list(cluster_config["modules"] or [])
+        if "modules" in job_defaults:
+            modules = list(job_defaults["modules"] or [])
+
+    resolved.update({k: v for k, v in cli_values.items() if v is not None})
+    resolved["modules"] = modules
+    validate_resources(resolved, cluster_config_path)
+    return resolved
+
+
+def validate_resources(resolved: dict, source) -> None:
+    """Reject resource values SLURM would silently misread.
+
+    Chiefly YAML 1.1 sexagesimal: an unquoted ``time: 12:00:00`` loads as the
+    integer 43200, which SLURM reads as 43200 *minutes* — a 60x wall-time
+    request. Fail loudly at generation time instead.
+    """
+    time_value = resolved.get("time")
+    if isinstance(time_value, int) or not _SLURM_TIME_RE.match(str(time_value)):
+        hint = ""
+        if isinstance(time_value, int):
+            hours, remainder = divmod(time_value, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            hint = (
+                f" YAML parsed it as the integer {time_value}; quote it "
+                f'("{hours:02d}:{minutes:02d}:{seconds:02d}") in {source}.'
+            )
+        raise typer.BadParameter(
+            f"Invalid SLURM wall time {time_value!r}. Expected forms: "
+            f"MM, HH:MM, HH:MM:SS, D-HH, D-HH:MM, D-HH:MM:SS.{hint}"
+        )
 
 
 def create_sbatch_script(
@@ -85,7 +263,12 @@ def create_sbatch_script(
     command="",
     n_jobs_in_array=1,
     env_vars="",
+    modules=None,
+    project_root=None,
 ):
+    # `is None` (absent), not falsy: an empty list means "load no modules".
+    module_list = DEFAULT_MODULES if modules is None else modules
+    module_loads = "\n".join(f"module load {module}" for module in module_list)
     sbatch_script = SBATCH_TEMPLATE.format(
         account=account,
         partition=partition,
@@ -94,11 +277,15 @@ def create_sbatch_script(
         mem=mem,
         job_name=job_name,
         time=time,
-        output=output,
-        error=error,
+        # SLURM splits #SBATCH directive lines on whitespace; quoting keeps a
+        # path with spaces in one piece (a no-op for ordinary paths).
+        output=shlex.quote(str(output)),
+        error=shlex.quote(str(error)),
         command=command,
         n_jobs_in_array=n_jobs_in_array,
         env_vars=env_vars,
+        module_loads=module_loads,
+        project_root=shlex.quote(str(project_root or PROJECT_ROOT)),
     )
     return sbatch_script
 
@@ -108,16 +295,35 @@ def write_sbatch(script, sbatch_script):
         f.write(sbatch_script)
 
 
-def submit_sbatch(script, logger):
+def submit_sbatch(script, logger) -> int | None:
+    """Submit the script via sbatch; return the SLURM job id, or None on failure.
+
+    The job id is parsed from sbatch's "Submitted batch job <id>" stdout line.
+    Failures (nonzero exit, missing sbatch binary, unparseable output) are
+    logged and yield None — the caller decides the process exit code.
+    """
     try:
         result = subprocess.run(
-            ["sbatch", script], capture_output=True, text=True, check=False
+            ["sbatch", str(script)], capture_output=True, text=True, check=False
         )
-        logger.info(result.stdout)
-        if result.stderr:
-            logger.error(result.stderr)
-    except Exception as e:
+    except OSError as e:  # sbatch binary missing / not executable
         logger.error(f"Failed to submit job: {e}")
+        return None
+    if result.stdout:
+        logger.info(result.stdout.strip())
+    if result.stderr:
+        logger.error(result.stderr.strip())
+    if result.returncode != 0:
+        logger.error(f"sbatch exited with code {result.returncode}")
+        return None
+    match = re.search(r"Submitted batch job (\d+)", result.stdout)
+    if match is None:
+        logger.error(
+            "sbatch succeeded but its output did not contain "
+            f"'Submitted batch job <id>': {result.stdout!r}"
+        )
+        return None
+    return int(match.group(1))
 
 
 def get_basic_config_from_yaml(yaml_config_path: str | Path):
@@ -185,26 +391,51 @@ def handle_job(
     config_path: Path,
     output_path: Path,
     log_level: str,
-    time: str,
     script_only: bool,
-    account: str = "default",
-    partition: str = "batch",
-    num_gpus: int = 0,
-    cores: int = 1,
-    mem: str = "16G",
+    account: str | None = None,
+    partition: str | None = None,
+    num_gpus: int | None = None,
+    cores: int | None = None,
+    mem: str | None = None,
+    time: str | None = None,
+    cluster_config: Path = None,
     n_jobs_in_array: int = 1,
+    n_files: int = None,
     training_data_folder: Path = None,
     network_id: int = 0,
     dl_workers: int = 1,
     data_generation_experiment_id: str = None,
 ):
+    # Case-insensitive, and validated: getattr(logging, "info") returns the
+    # *function*, which basicConfig rejects with a TypeError traceback — and
+    # the JSON contract line would never be printed.
+    level = getattr(logging, str(log_level).upper(), None)
+    if not isinstance(level, int):
+        raise typer.BadParameter(
+            f"Unknown log level {log_level!r}. Expected one of: "
+            "DEBUG, INFO, WARNING, ERROR, CRITICAL."
+        )
     logging.basicConfig(
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
-        level=getattr(logging, log_level),
+        level=level,
     )
     logger = logging.getLogger("gen_sbatch")
     target = output_path.resolve()
+
+    resources = resolve_resources(
+        command_name,
+        cluster_config,
+        {
+            "account": account,
+            "partition": partition,
+            "num_gpus": num_gpus,
+            "cores": cores,
+            "mem": mem,
+            "time": time,
+        },
+        logger=logger,
+    )
 
     # Initialize MLflow parameters
     mlflow_run_id = None  # For training: parent run ID
@@ -213,10 +444,17 @@ def handle_job(
     mlflow_experiment_id = None  # For data generation: to report to user
     env_vars = ""
 
-    if MLFLOW_AVAILABLE:
+    # --script-only is side-effect-free: no experiment is created, no run is
+    # started, and no MLflow wiring is embedded in the generated script. A
+    # previous version created an empty orphan run per --script-only call.
+    if MLFLOW_AVAILABLE and not script_only:
         try:
             # Set tracking URI from environment or use default (SQLite)
-            tracking_uri = os.getenv("MLFLOW_TRACKING_URI", "sqlite:///mlflow.db")
+            # Absolute, so the submitting process and every compute-node
+            # worker agree on which database the experiment lives in.
+            tracking_uri = absolutize_tracking_uri(
+                os.getenv("MLFLOW_TRACKING_URI", "sqlite:///mlflow.db")
+            )
             mlflow.set_tracking_uri(tracking_uri)
             logger.info(f"MLflow tracking URI: {tracking_uri}")
 
@@ -266,10 +504,15 @@ def handle_job(
                 mlflow_experiment_name = experiment_name
 
                 # Environment variables for the SBATCH script
-                env_vars = f"export MLFLOW_EXPERIMENT_NAME={experiment_name}\n"
-                env_vars += f"export MLFLOW_TRACKING_URI={tracking_uri}"
+                env_vars = (
+                    f"export MLFLOW_EXPERIMENT_NAME={shlex.quote(experiment_name)}\n"
+                    f"export MLFLOW_TRACKING_URI={shlex.quote(tracking_uri)}"
+                )
                 if artifact_location:
-                    env_vars += f"\nexport MLFLOW_ARTIFACT_LOCATION={artifact_location}"
+                    env_vars += (
+                        "\nexport MLFLOW_ARTIFACT_LOCATION="
+                        f"{shlex.quote(artifact_location)}"
+                    )
 
             elif command_name in ["jaxtrain", "torchtrain"]:
                 # Training experiment
@@ -326,10 +569,15 @@ def handle_job(
                 logger.info(f"MLflow training run initialized: {mlflow_run_id}")
 
                 # Prepare env vars for sbatch script
-                env_vars = f"export MLFLOW_EXPERIMENT_NAME={experiment_name}\n"
-                env_vars += f"export MLFLOW_TRACKING_URI={tracking_uri}"
+                env_vars = (
+                    f"export MLFLOW_EXPERIMENT_NAME={shlex.quote(experiment_name)}\n"
+                    f"export MLFLOW_TRACKING_URI={shlex.quote(tracking_uri)}"
+                )
                 if artifact_location:
-                    env_vars += f"\nexport MLFLOW_ARTIFACT_LOCATION={artifact_location}"
+                    env_vars += (
+                        "\nexport MLFLOW_ARTIFACT_LOCATION="
+                        f"{shlex.quote(artifact_location)}"
+                    )
 
         except Exception as e:
             logger.error(f"Failed to initialize MLflow: {e}")
@@ -347,54 +595,74 @@ def handle_job(
         mlflow_run_id=mlflow_run_id,
         data_generation_experiment_id=data_generation_experiment_id,
     )
+    if command_name == "generate" and n_files is not None:
+        params["n-files"] = n_files
     command = create_command(command_name, **params)
     logger.info(f"Generated command: {command}")
     basic_config = get_basic_config_from_yaml(params["config-path"])
     job_name = f"{basic_config['MODEL']}_{command_name}_sbatch"
-    script = f"{basic_config['MODEL']}_{command_name}_sbatch.sh"
+
+    # Scripts and SLURM logs live under <output_path>/runs/, timestamped —
+    # repeated invocations never overwrite each other (previously the script
+    # landed in CWD under a fixed name).
+    runs_dir = target / "runs"
+    runs_dir.mkdir(exist_ok=True, parents=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+    script = runs_dir / f"{timestamp}_{job_name}.sh"
+
     sbatch_kwargs = dict(
-        account=account,
-        partition=partition,
-        num_gpus=num_gpus,
-        cores=cores,
-        mem=mem,
+        account=resources["account"],
+        partition=resources["partition"],
+        num_gpus=resources["num_gpus"],
+        cores=resources["cores"],
+        mem=resources["mem"],
         job_name=job_name,
         # %A_%a = array job id + task index. The template always emits
         # --array, so every task would otherwise append to one shared pair of
         # files and interleave its output with the others'.
-        output=f"{job_name}_%A_%a.out",
-        error=f"{job_name}_%A_%a.err",
-        time=time,
+        output=str(runs_dir / f"{job_name}_%A_%a.out"),
+        error=str(runs_dir / f"{job_name}_%A_%a.err"),
+        time=resources["time"],
         command=command,
         n_jobs_in_array=n_jobs_in_array,
         env_vars=env_vars,
+        modules=resources["modules"],
     )
     sbatch_script = create_sbatch_script(**sbatch_kwargs)
     write_sbatch(script, sbatch_script)
+
+    # The one machine-readable line on stdout, regardless of log level: the
+    # laptop driver's API. Logging goes to stderr, so stdout carries only this.
+    result_record = {
+        "command": command,
+        "job_id": None,
+        "mlflow_experiment_id": mlflow_experiment_id,
+        "mlflow_run_id": mlflow_run_id,
+        "sbatch_script": str(script),
+        "output_path": str(target),
+        "account": resources["account"],
+        "partition": resources["partition"],
+    }
+
     if script_only:
         logger.info(f"Generated sbatch script: {script}")
-        if MLFLOW_AVAILABLE and mlflow.active_run():
-            mlflow.end_run()
+        print(json.dumps(result_record))
         return
-    target.mkdir(exist_ok=True, parents=True)
+
     if command_name == "generate":
         logger.info(f"Simulated data output folder: {target}")
     else:
         logger.info(f"Trained networks output folder: {target}")
-    submit_sbatch(script, logger)
+    job_id = submit_sbatch(script, logger)
+    result_record["job_id"] = job_id
 
     if MLFLOW_AVAILABLE and mlflow.active_run():
         mlflow.end_run()
 
-    # Return experiment ID for data generation (useful for chaining to training)
-    if command_name == "generate" and mlflow_experiment_id:
-        logger.info("=" * 60)
-        logger.info(f"DATA GENERATION EXPERIMENT ID: {mlflow_experiment_id}")
-        logger.info(
-            "Use this ID with training commands via --data-generation-experiment-id"
-        )
-        logger.info("=" * 60)
-
+    print(json.dumps(result_record))
+    if job_id is None:
+        logger.error("Job submission failed")
+        raise typer.Exit(code=1)
     logger.info("Job submitted successfully")
 
 
@@ -407,18 +675,39 @@ def generate(
         ..., help="Path to output folder for simulated data"
     ),
     n_jobs_in_array: int = typer.Option(1, help="Size of the job array"),
-    account: str = typer.Option("default", help="Condo to run the SBATCH job on"),
+    n_files: int = typer.Option(
+        None, help="Number of files each worker generates (passed to `generate`)"
+    ),
+    cluster_config: Path = typer.Option(
+        None,
+        help="Cluster inventory YAML (e.g. configs/cluster/oscar.yaml); its "
+        "job_defaults section supplies account/partition/resources for this "
+        "job kind. Explicit flags below override it.",
+    ),
+    account: str = typer.Option(
+        None, help="Condo to run the SBATCH job on [default: from cluster config]"
+    ),
     partition: str = typer.Option(
-        "batch", help="Partition to run the SBATCH script on"
+        None,
+        help="Partition to run the SBATCH script on [default: from cluster config]",
     ),
     num_gpus: int = typer.Option(
-        0, help="Number of GPUs requested (for use on gpu partition)"
+        None, help="Number of GPUs requested [default: from cluster config]"
     ),
-    mem: str = typer.Option("16G", help="Memory limit for each job"),
-    time: str = typer.Option("00:30:00", help="Wall time limit for each job"),
-    cores: int = typer.Option(1, help="Number of tasks (cores) to run in parallel"),
+    mem: str = typer.Option(
+        None, help="Memory limit for each job [default: from cluster config]"
+    ),
+    time: str = typer.Option(
+        None, help="Wall time limit for each job [default: from cluster config]"
+    ),
+    cores: int = typer.Option(
+        None, help="Number of cores per job [default: from cluster config]"
+    ),
     script_only: bool = typer.Option(
-        False, help="Generate the sbatch script without submitting the job"
+        False,
+        help="Generate the sbatch script without submitting the job. "
+        "Side-effect-free: no MLflow experiment/run is created and no MLflow "
+        "wiring is embedded in the script.",
     ),
     log_level: str = typer.Option(
         "WARNING", help="Set the log level", show_default=True
@@ -432,12 +721,14 @@ def generate(
         log_level=log_level,
         time=time,
         script_only=script_only,
+        cluster_config=cluster_config,
         account=account,
         partition=partition,
         num_gpus=num_gpus,
         cores=cores,
         mem=mem,
         n_jobs_in_array=n_jobs_in_array,
+        n_files=n_files,
     )
 
 
@@ -459,23 +750,39 @@ def train_command(command_name: str):
             help="MLflow Experiment ID of the data generation experiment. "
             "If provided, training data lineage will be logged.",
         ),
-        account: str = typer.Option("default", help="Condo to run the SBATCH job on"),
+        cluster_config: Path = typer.Option(
+            None,
+            help="Cluster inventory YAML (e.g. configs/cluster/oscar.yaml); its "
+            "job_defaults section supplies account/partition/resources for "
+            "this job kind. Explicit flags below override it.",
+        ),
+        account: str = typer.Option(
+            None, help="Condo to run the SBATCH job on [default: from cluster config]"
+        ),
         partition: str = typer.Option(
-            "batch", help="Partition to run the SBATCH script on"
+            None,
+            help="Partition to run the SBATCH script on [default: from cluster config]",
         ),
         num_gpus: int = typer.Option(
-            0, help="Number of GPUs requested (for use on gpu partition)"
+            None, help="Number of GPUs requested [default: from cluster config]"
         ),
         cores: int = typer.Option(
-            1, help="Number of tasks (cores) to run in parallel"
+            None, help="Number of cores per job [default: from cluster config]"
         ),
         dl_workers: int = typer.Option(
             1, help="Number of cores to use with the dataloader class"
         ),
-        time: str = typer.Option("00:30:00", help="Wall time limit for each job"),
-        mem: str = typer.Option("16G", help="Memory limit for each job"),
+        time: str = typer.Option(
+            None, help="Wall time limit for each job [default: from cluster config]"
+        ),
+        mem: str = typer.Option(
+            None, help="Memory limit for each job [default: from cluster config]"
+        ),
         script_only: bool = typer.Option(
-            False, help="Generate the sbatch script without submitting the job"
+            False,
+            help="Generate the sbatch script without submitting the job. "
+            "Side-effect-free: no MLflow experiment/run is created and no "
+            "MLflow wiring is embedded in the script.",
         ),
         log_level: str = typer.Option(
             "WARNING", help="Set the log level", show_default=True
@@ -489,6 +796,7 @@ def train_command(command_name: str):
             log_level=log_level,
             time=time,
             script_only=script_only,
+            cluster_config=cluster_config,
             account=account,
             partition=partition,
             num_gpus=num_gpus,

--- a/sbatch_scripts/sample_generate_sbatch.sh
+++ b/sbatch_scripts/sample_generate_sbatch.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 
 # Example SBATCH script produced by sbatch_scripts/gen_sbatch.py
-# (paths shown as placeholders). Regenerate with the matching gen_sbatch.py command.
+# (paths shown as placeholders). Regenerate with the matching gen_sbatch.py
+# command; the real file is written to <output-path>/runs/<timestamp>_<job>.sh.
 
-#SBATCH --account=default
+#SBATCH --account=carney-frankmj-condo
 #SBATCH -p batch --gres=gpu:0
-#SBATCH -c 4
-#SBATCH --mem=8G
+#SBATCH -c 1
+#SBATCH --mem=16G
 #SBATCH -J ddm_generate_sbatch
-#SBATCH --time=02:00:00
-#SBATCH --output=ddm_generate_sbatch_%A_%a.out
-#SBATCH --error=ddm_generate_sbatch_%A_%a.err
+#SBATCH --time=04:00:00
+#SBATCH --output=/path/to/output/runs/ddm_generate_sbatch_%A_%a.out
+#SBATCH --error=/path/to/output/runs/ddm_generate_sbatch_%A_%a.err
 #SBATCH --array=1-10
 
 module load python
 module load gcc
 
+# The uv project is resolved from the working directory, and SLURM starts the
+# job in whatever directory sbatch was invoked from — $HOME for a driver that
+# submits over ssh. Pin it to the checkout that generated this script.
+cd /path/to/LAN_pipeline_minimal || exit 1
+
 # MLflow environment variables
 export MLFLOW_EXPERIMENT_NAME=ddm-data-generation
-export MLFLOW_TRACKING_URI=sqlite:///mlflow.db
+export MLFLOW_TRACKING_URI=sqlite:////shared/storage/mlflow/tracking.db
 
 if ! python -m uv --version >/dev/null 2>&1; then
   if [ -n "${VIRTUAL_ENV:-}" ]; then
@@ -27,4 +33,4 @@ if ! python -m uv --version >/dev/null 2>&1; then
     python -m pip install --user uv
   fi
 fi
-python -m uv run generate --config-path configs/examples/data_generation.yaml --log-level WARNING --output /path/to/output --mlflow-run-name ddm-worker-$SLURM_ARRAY_TASK_ID --mlflow-experiment-name ddm-data-generation
+python -m uv run generate --config-path configs/examples/data_generation.yaml --log-level WARNING --output /path/to/output --mlflow-run-name ddm-worker-"$SLURM_ARRAY_TASK_ID" --mlflow-experiment-name ddm-data-generation

--- a/sbatch_scripts/sample_jaxtrain_sbatch.sh
+++ b/sbatch_scripts/sample_jaxtrain_sbatch.sh
@@ -1,24 +1,30 @@
 #!/bin/bash
 
 # Example SBATCH script produced by sbatch_scripts/gen_sbatch.py
-# (paths shown as placeholders). Regenerate with the matching gen_sbatch.py command.
+# (paths shown as placeholders). Regenerate with the matching gen_sbatch.py
+# command; the real file is written to <output-path>/runs/<timestamp>_<job>.sh.
 
-#SBATCH --account=default
-#SBATCH -p gpu --gres=gpu:1
-#SBATCH -c 1
-#SBATCH --mem=16G
+#SBATCH --account=carney-frankmj-condo
+#SBATCH -p batch --gres=gpu:0
+#SBATCH -c 2
+#SBATCH --mem=32G
 #SBATCH -J ddm_jaxtrain_sbatch
-#SBATCH --time=00:30:00
-#SBATCH --output=ddm_jaxtrain_sbatch_%A_%a.out
-#SBATCH --error=ddm_jaxtrain_sbatch_%A_%a.err
+#SBATCH --time=12:00:00
+#SBATCH --output=/path/to/networks/runs/ddm_jaxtrain_sbatch_%A_%a.out
+#SBATCH --error=/path/to/networks/runs/ddm_jaxtrain_sbatch_%A_%a.err
 #SBATCH --array=1-1
 
 module load python
 module load gcc
 
+# The uv project is resolved from the working directory, and SLURM starts the
+# job in whatever directory sbatch was invoked from — $HOME for a driver that
+# submits over ssh. Pin it to the checkout that generated this script.
+cd /path/to/LAN_pipeline_minimal || exit 1
+
 # MLflow environment variables
 export MLFLOW_EXPERIMENT_NAME=ddm-training
-export MLFLOW_TRACKING_URI=sqlite:///mlflow.db
+export MLFLOW_TRACKING_URI=sqlite:////shared/storage/mlflow/tracking.db
 
 if ! python -m uv --version >/dev/null 2>&1; then
   if [ -n "${VIRTUAL_ENV:-}" ]; then

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,107 @@
+"""Shared fixtures for the gen_sbatch test suite.
+
+sbatch_scripts/ is not a package (the repo becomes an installable tool in a
+later PR), so the module is imported by path.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "sbatch_scripts"))
+
+
+@pytest.fixture
+def model_config(tmp_path):
+    """Minimal pipeline YAML config (the MODEL key is what gen_sbatch reads)."""
+    path = tmp_path / "config.yaml"
+    path.write_text("MODEL: ddm\n")
+    return path
+
+
+@pytest.fixture
+def cluster_config(tmp_path):
+    """A cluster inventory file exercising job_defaults + modules."""
+    path = tmp_path / "oscar.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "condos": {
+                    "test-condo": {
+                        "partitions": ["batch", "gpu"],
+                        "suited_for": ["generate"],
+                        "verified": False,
+                    }
+                },
+                "job_defaults": {
+                    "generate": {
+                        "account": "test-condo",
+                        "partition": "batch",
+                        "cores": 4,
+                        "mem": "8G",
+                        "num_gpus": 0,
+                        "time": "02:00:00",
+                    },
+                    "jaxtrain": {
+                        "account": "test-condo",
+                        "partition": "gpu",
+                        "cores": 2,
+                        "mem": "32G",
+                        "num_gpus": 1,
+                        "time": "08:00:00",
+                    },
+                },
+                "modules": ["python", "gcc", "cuda"],
+            }
+        )
+    )
+    return path
+
+
+@pytest.fixture
+def isolated_mlflow(tmp_path, monkeypatch):
+    """Point MLflow at a throwaway sqlite DB; return its path."""
+    db = tmp_path / "mlflow_test.db"
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", f"sqlite:///{db}")
+    monkeypatch.delenv("MLFLOW_ARTIFACT_LOCATION", raising=False)
+    return db
+
+
+@pytest.fixture
+def fake_sbatch_ok(monkeypatch):
+    """subprocess.run stub: sbatch succeeds with job id 12345; records calls."""
+    import gen_sbatch
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+            stdout = "Submitted batch job 12345\n"
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(gen_sbatch.subprocess, "run", fake_run)
+    return calls
+
+
+@pytest.fixture
+def fake_sbatch_fail(monkeypatch):
+    """subprocess.run stub: sbatch fails (bad account)."""
+    import gen_sbatch
+
+    def fake_run(cmd, **kwargs):
+        class Result:
+            returncode = 1
+            stdout = ""
+            stderr = "sbatch: error: Invalid account or account/partition combination specified\n"
+
+        return Result()
+
+    monkeypatch.setattr(gen_sbatch.subprocess, "run", fake_run)

--- a/tests/test_gen_sbatch.py
+++ b/tests/test_gen_sbatch.py
@@ -52,8 +52,6 @@ class TestQuoting:
         assert "--config-path '/tmp/my configs/config.yaml'" in cmd
 
     def test_shell_metacharacters_are_neutralized(self):
-        import shlex
-
         cmd = create_command("generate", **{"output": "/tmp/$(rm -rf x); echo"})
         # single-quoted → the shell sees one literal argument, nothing executes
         assert "'/tmp/$(rm -rf x); echo'" in cmd
@@ -451,7 +449,10 @@ class TestGeneratedScriptRuntime:
         repo_root = Path(gen_sbatch.__file__).resolve().parents[1]
         assert f"cd {repo_root} || exit 1" in script
 
-    def test_slurm_log_paths_survive_spaces(self, model_config, tmp_path):
+    def test_output_path_with_spaces_is_rejected_upfront(self, model_config, tmp_path):
+        # SLURM reads #SBATCH --output= literally to end of line and does not
+        # dequote, so whitespace cannot be expressed at all. Fail at
+        # generation time with the reason, not at submission with a parse error.
         out = tmp_path / "out dir with spaces"
         result = runner.invoke(
             app,
@@ -464,15 +465,20 @@ class TestGeneratedScriptRuntime:
                 "--script-only",
             ],
         )
-        assert result.exit_code == 0, result.output
-        script = next((out / "runs").glob("*.sh")).read_text()
-        for line in script.splitlines():
-            if line.startswith("#SBATCH --output=") or line.startswith(
-                "#SBATCH --error="
-            ):
-                value = line.split("=", 1)[1]
-                # one shell word, not split at the space
-                assert len(shlex.split(value)) == 1, line
+        assert result.exit_code != 0
+        assert "whitespace" in result.output
+
+    def test_slurm_log_directives_are_unquoted(self, model_config, tmp_path):
+        script = self.script_for(model_config, tmp_path)
+        directives = [
+            line
+            for line in script.splitlines()
+            if line.startswith(("#SBATCH --output=", "#SBATCH --error="))
+        ]
+        assert len(directives) == 2
+        for line in directives:
+            value = line.split("=", 1)[1]
+            assert not value.startswith(("'", '"')), line
 
     def test_tracking_uri_embedded_absolute(self, model_config, tmp_path, monkeypatch):
         # A relative sqlite URI resolves against each worker's own CWD, so
@@ -553,13 +559,103 @@ class TestResourceValidation:
         assert "43200" in str(excinfo.value)
         assert "12:00:00" in str(excinfo.value)  # the quoted form to use
 
+    def test_bare_integer_time_is_rejected_with_both_readings(self, tmp_path):
+        # `time: 30` is ambiguous after parsing: the user may have written 30
+        # (minutes) or 0:30, which YAML also loads as 30. The message must
+        # offer both quoted forms rather than guess.
+        config = tmp_path / "cluster.yaml"
+        config.write_text("job_defaults:\n  generate:\n    time: 30\n")
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_resources("generate", config, {})
+        message = str(excinfo.value)
+        assert 'time: "30"' in message
+        assert 'time: "00:00:30"' in message
+
     @pytest.mark.parametrize(
         "value", ["30", "4:00", "12:00:00", "1-00", "2-06:30", "1-00:00:00"]
     )
     def test_valid_slurm_time_forms_accepted(self, value, tmp_path):
+        # Quoted strings, including a bare minute count, pass through.
         config = tmp_path / "cluster.yaml"
         config.write_text(f'job_defaults:\n  generate:\n    time: "{value}"\n')
         assert resolve_resources("generate", config, {})["time"] == value
+
+    def test_missing_cluster_config_is_a_clean_cli_error(self, model_config, tmp_path):
+        # A mistyped path must not traceback: the driver would get no JSON.
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--cluster-config",
+                str(tmp_path / "nope.yaml"),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code != 0
+        assert result.exception is None or isinstance(result.exception, SystemExit)
+        assert "does not exist" in result.output
+
+
+class TestModelNameSanitization:
+    @pytest.mark.parametrize(
+        ("model", "expected_fragment"),
+        [
+            ("../../etc/ddm", "_.._etc_ddm"),  # leading dots also stripped
+            ("ddm/../../x", "ddm_.._.._x"),
+            ("my ddm", "my_ddm"),
+            ("ddm;rm -rf /", "ddm_rm_-rf__"),
+        ],
+    )
+    def test_hostile_model_names_stay_inside_runs_dir(
+        self, tmp_path, model, expected_fragment
+    ):
+        # MODEL comes from a user-supplied YAML and lands in the script
+        # filename, the SLURM job name and the log filenames.
+        config = tmp_path / "config.yaml"
+        config.write_text(f'MODEL: "{model}"\n')
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(config),
+                "--output-path",
+                str(out),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script_path = Path(last_json_line(result.output)["sbatch_script"])
+        assert script_path.parent == (out / "runs").resolve(), script_path
+        assert expected_fragment in script_path.name
+        assert script_path.exists()
+
+    def test_job_name_directive_is_a_single_token(self, tmp_path):
+        config = tmp_path / "config.yaml"
+        config.write_text('MODEL: "my ddm"\n')
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(config),
+                "--output-path",
+                str(out),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = next((out / "runs").glob("*.sh")).read_text()
+        job_line = next(
+            line for line in script.splitlines() if line.startswith("#SBATCH -J ")
+        )
+        assert len(job_line.split()) == 3, job_line
 
 
 class TestLogLevel:

--- a/tests/test_gen_sbatch.py
+++ b/tests/test_gen_sbatch.py
@@ -1,0 +1,610 @@
+"""Tests for gen_sbatch: quoting, job-id capture, the JSON contract,
+--script-only purity, and cluster-config resource resolution.
+
+The JSON line on stdout is the laptop driver's API — its shape is the
+load-bearing contract here.
+"""
+
+import json
+import logging
+import shlex
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+import gen_sbatch
+from gen_sbatch import (
+    absolutize_tracking_uri,
+    app,
+    create_command,
+    quote_param_value,
+    resolve_resources,
+    submit_sbatch,
+)
+
+runner = CliRunner()
+
+JSON_KEYS = {
+    "command",
+    "job_id",
+    "mlflow_experiment_id",
+    "mlflow_run_id",
+    "sbatch_script",
+    "output_path",
+    "account",
+    "partition",
+}
+
+
+def last_json_line(output: str) -> dict:
+    lines = [ln for ln in output.strip().splitlines() if ln.startswith("{")]
+    assert lines, f"no JSON line on stdout: {output!r}"
+    return json.loads(lines[-1])
+
+
+class TestQuoting:
+    def test_paths_with_spaces_are_quoted(self):
+        cmd = create_command(
+            "generate", **{"config-path": "/tmp/my configs/config.yaml"}
+        )
+        assert "--config-path '/tmp/my configs/config.yaml'" in cmd
+
+    def test_shell_metacharacters_are_neutralized(self):
+        import shlex
+
+        cmd = create_command("generate", **{"output": "/tmp/$(rm -rf x); echo"})
+        # single-quoted → the shell sees one literal argument, nothing executes
+        assert "'/tmp/$(rm -rf x); echo'" in cmd
+        assert shlex.split(cmd) == [
+            "generate",
+            "--output",
+            "/tmp/$(rm -rf x); echo",
+        ]
+
+    def test_mlflow_run_name_keeps_slurm_var_expandable(self):
+        # SLURM substitutes $SLURM_ARRAY_TASK_ID inside the job; single-quoting
+        # would freeze the literal string and every worker would share a name.
+        cmd = create_command(
+            "generate", **{"mlflow-run-name": "ddm-worker-$SLURM_ARRAY_TASK_ID"}
+        )
+        assert '--mlflow-run-name ddm-worker-"$SLURM_ARRAY_TASK_ID"' in cmd
+
+    def test_expandable_value_quotes_literal_part(self):
+        # The SLURM var is isolated in its own double-quoted segment; the
+        # literal part goes through shlex.quote, which adds nothing when the
+        # text is already shell-safe (as an ordinary model name is).
+        assert (
+            quote_param_value("mlflow-run-name", "ddm-worker-$SLURM_ARRAY_TASK_ID")
+            == 'ddm-worker-"$SLURM_ARRAY_TASK_ID"'
+        )
+        # ...and quotes it when it is not
+        assert (
+            quote_param_value("mlflow-run-name", "ddm x-worker-$SLURM_ARRAY_TASK_ID")
+            == "'ddm x-worker-'\"$SLURM_ARRAY_TASK_ID\""
+        )
+
+    @pytest.mark.parametrize(
+        "hostile",
+        [
+            "ddm`id`",
+            "ddm$(id)",
+            "ddm; id",
+            'ddm"; id; "',
+            "ddm$HOME",
+            "ddm\\`id\\`",
+        ],
+    )
+    def test_command_substitution_in_expandable_value_is_inert(self, hostile):
+        """The model name comes from a user-supplied YAML and reaches the run
+        name; nothing in it may execute on the compute node."""
+        import subprocess
+
+        rendered = quote_param_value(
+            "mlflow-run-name", f"{hostile}-worker-$SLURM_ARRAY_TASK_ID"
+        )
+        # Ask a real bash what argument the job would actually receive.
+        out = subprocess.run(
+            ["bash", "-c", f"printf '%s' {rendered}"],
+            capture_output=True,
+            text=True,
+            env={"SLURM_ARRAY_TASK_ID": "7", "PATH": "/usr/bin:/bin"},
+        )
+        assert out.returncode == 0, out.stderr
+        assert out.stdout == f"{hostile}-worker-7", out.stdout
+
+    def test_dollar_in_non_expandable_param_stays_literal(self):
+        import subprocess
+
+        rendered = quote_param_value("output", "/data/$USER/out")
+        out = subprocess.run(
+            ["bash", "-c", f"printf '%s' {rendered}"],
+            capture_output=True,
+            text=True,
+            env={"USER": "someone", "PATH": "/usr/bin:/bin"},
+        )
+        assert out.stdout == "/data/$USER/out"
+
+
+class TestSubmitSbatch:
+    def test_parses_job_id(self, fake_sbatch_ok, tmp_path):
+        job_id = submit_sbatch(tmp_path / "job.sh", logging.getLogger("t"))
+        assert job_id == 12345
+
+    def test_failure_returns_none(self, fake_sbatch_fail, tmp_path):
+        assert submit_sbatch(tmp_path / "job.sh", logging.getLogger("t")) is None
+
+    def test_missing_binary_returns_none(self, monkeypatch, tmp_path):
+        def raise_oserror(cmd, **kwargs):
+            raise FileNotFoundError("sbatch")
+
+        monkeypatch.setattr(gen_sbatch.subprocess, "run", raise_oserror)
+        assert submit_sbatch(tmp_path / "job.sh", logging.getLogger("t")) is None
+
+    def test_unparseable_stdout_returns_none(self, monkeypatch, tmp_path):
+        def fake_run(cmd, **kwargs):
+            class Result:
+                returncode = 0
+                stdout = "something unexpected\n"
+                stderr = ""
+
+            return Result()
+
+        monkeypatch.setattr(gen_sbatch.subprocess, "run", fake_run)
+        assert submit_sbatch(tmp_path / "job.sh", logging.getLogger("t")) is None
+
+
+class TestJsonContract:
+    def test_submit_emits_json_with_job_id(
+        self, model_config, tmp_path, fake_sbatch_ok, isolated_mlflow
+    ):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            ["generate", "--config-path", str(model_config), "--output-path", str(out)],
+        )
+        assert result.exit_code == 0, result.output
+        record = last_json_line(result.output)
+        assert set(record) == JSON_KEYS
+        assert record["job_id"] == 12345
+        assert record["output_path"] == str(out.resolve())
+        assert record["sbatch_script"].endswith(".sh")
+        # generate creates a per-model experiment; its id is the chaining key
+        assert record["mlflow_experiment_id"] is not None
+
+    def test_json_emitted_even_at_default_log_level(
+        self, model_config, tmp_path, fake_sbatch_ok, isolated_mlflow
+    ):
+        # No --log-level: WARNING suppresses all info logging, the JSON line
+        # must still be there (this was the suppressed-experiment-id bug).
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 0
+        assert last_json_line(result.output)["mlflow_experiment_id"] is not None
+
+    def test_submit_failure_exits_nonzero_with_json(
+        self, model_config, tmp_path, fake_sbatch_fail, isolated_mlflow
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert last_json_line(result.output)["job_id"] is None
+
+
+class TestScriptOnly:
+    def invoke_script_only(self, model_config, out, extra=()):
+        return runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--script-only",
+                *extra,
+            ],
+        )
+
+    def test_writes_script_under_output_runs(self, model_config, tmp_path):
+        out = tmp_path / "out"
+        result = self.invoke_script_only(model_config, out)
+        assert result.exit_code == 0, result.output
+        record = last_json_line(result.output)
+        scripts = list((out / "runs").glob("*.sh"))
+        assert len(scripts) == 1
+        assert record["sbatch_script"] == str(scripts[0])
+        assert record["job_id"] is None
+
+    def test_repeated_invocations_do_not_overwrite(self, model_config, tmp_path):
+        out = tmp_path / "out"
+        assert self.invoke_script_only(model_config, out).exit_code == 0
+        assert self.invoke_script_only(model_config, out).exit_code == 0
+        assert len(list((out / "runs").glob("*.sh"))) == 2
+
+    def test_no_mlflow_side_effects(self, model_config, tmp_path, isolated_mlflow):
+        # Previously each --script-only train call left an empty orphan run.
+        result = self.invoke_script_only(model_config, tmp_path / "out")
+        assert result.exit_code == 0
+        assert not isolated_mlflow.exists(), "script-only must not touch MLflow"
+
+    def test_train_script_only_no_orphan_run(
+        self, model_config, tmp_path, isolated_mlflow
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "jaxtrain",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--training-data-folder",
+                str(tmp_path),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert not isolated_mlflow.exists()
+        assert last_json_line(result.output)["mlflow_run_id"] is None
+
+
+class TestResourceResolution:
+    def test_builtin_fallbacks_without_config(self):
+        resources = resolve_resources(
+            "generate",
+            None,
+            dict.fromkeys(("account", "partition", "num_gpus", "cores", "mem", "time")),
+        )
+        assert resources["account"] == "default"
+        assert resources["partition"] == "batch"
+        assert resources["modules"] == ["python", "gcc"]
+
+    def test_cluster_config_supplies_job_kind_defaults(
+        self, model_config, cluster_config, tmp_path
+    ):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--cluster-config",
+                str(cluster_config),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        record = last_json_line(result.output)
+        assert record["account"] == "test-condo"
+        assert record["partition"] == "batch"
+        script = (out / "runs").glob("*.sh").__next__().read_text()
+        assert "#SBATCH --account=test-condo" in script
+        assert "#SBATCH -c 4" in script
+        assert "#SBATCH --mem=8G" in script
+        assert "#SBATCH --time=02:00:00" in script
+        assert "module load cuda" in script
+
+    def test_job_kind_selects_its_own_defaults(
+        self, model_config, cluster_config, tmp_path
+    ):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "jaxtrain",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--training-data-folder",
+                str(tmp_path),
+                "--cluster-config",
+                str(cluster_config),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = (out / "runs").glob("*.sh").__next__().read_text()
+        assert "#SBATCH -p gpu --gres=gpu:1" in script
+        assert record_partition(result) == "gpu"
+
+    def test_explicit_flag_overrides_cluster_config(
+        self, model_config, cluster_config, tmp_path
+    ):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--cluster-config",
+                str(cluster_config),
+                "--account",
+                "my-other-condo",
+                "--cores",
+                "16",
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert last_json_line(result.output)["account"] == "my-other-condo"
+        script = (out / "runs").glob("*.sh").__next__().read_text()
+        assert "#SBATCH --account=my-other-condo" in script
+        assert "#SBATCH -c 16" in script
+        # non-overridden keys still come from the config
+        assert "#SBATCH --mem=8G" in script
+
+    def test_repo_oscar_yaml_parses_and_resolves(self):
+        from pathlib import Path
+
+        repo_yaml = (
+            Path(__file__).resolve().parent.parent
+            / "configs"
+            / "cluster"
+            / "oscar.yaml"
+        )
+        for kind in ("generate", "jaxtrain", "torchtrain"):
+            resources = resolve_resources(kind, repo_yaml, {})
+            assert resources["account"] == "carney-frankmj-condo"
+            assert set(resources) >= {
+                "account",
+                "partition",
+                "num_gpus",
+                "cores",
+                "mem",
+                "time",
+                "modules",
+            }
+
+
+class TestNFilesPassthrough:
+    def test_n_files_reaches_the_generate_command(self, model_config, tmp_path):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--n-files",
+                "7",
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = (out / "runs").glob("*.sh").__next__().read_text()
+        assert "--n-files 7" in script
+
+    def test_omitted_n_files_is_absent(self, model_config, tmp_path):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0
+        script = (out / "runs").glob("*.sh").__next__().read_text()
+        assert "--n-files" not in script
+
+
+def record_partition(result) -> str:
+    return last_json_line(result.output)["partition"]
+
+
+class TestGeneratedScriptRuntime:
+    """Properties the script must have when SLURM runs it on a compute node."""
+
+    def script_for(self, model_config, tmp_path, extra=()):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--script-only",
+                *extra,
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        return next((out / "runs").glob("*.sh")).read_text()
+
+    def test_pins_the_uv_project_directory(self, model_config, tmp_path):
+        # SLURM starts the job in the sbatch submission directory ($HOME for a
+        # driver submitting over ssh); `uv run <cmd>` there fails with
+        # "Failed to spawn" or silently resolves a foreign pyproject.toml.
+        script = self.script_for(model_config, tmp_path)
+        repo_root = Path(gen_sbatch.__file__).resolve().parents[1]
+        assert f"cd {repo_root} || exit 1" in script
+
+    def test_slurm_log_paths_survive_spaces(self, model_config, tmp_path):
+        out = tmp_path / "out dir with spaces"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = next((out / "runs").glob("*.sh")).read_text()
+        for line in script.splitlines():
+            if line.startswith("#SBATCH --output=") or line.startswith(
+                "#SBATCH --error="
+            ):
+                value = line.split("=", 1)[1]
+                # one shell word, not split at the space
+                assert len(shlex.split(value)) == 1, line
+
+    def test_tracking_uri_embedded_absolute(self, model_config, tmp_path, monkeypatch):
+        # A relative sqlite URI resolves against each worker's own CWD, so
+        # workers would write to a different database than the one whose
+        # experiment id the JSON contract reports.
+        monkeypatch.setenv("MLFLOW_TRACKING_URI", "sqlite:///mlflow.db")
+        monkeypatch.chdir(tmp_path)
+        assert absolutize_tracking_uri("sqlite:///mlflow.db") == (
+            f"sqlite:///{(tmp_path / 'mlflow.db').resolve()}"
+        )
+
+    def test_absolutize_leaves_server_and_absolute_uris_alone(self):
+        assert (
+            absolutize_tracking_uri("http://localhost:5000") == "http://localhost:5000"
+        )
+        assert (
+            absolutize_tracking_uri("sqlite:////abs/path/mlflow.db")
+            == "sqlite:////abs/path/mlflow.db"
+        )
+
+
+class TestModulesResolution:
+    def write_config(self, tmp_path, payload):
+        import yaml as _yaml
+
+        path = tmp_path / "cluster.yaml"
+        path.write_text(_yaml.safe_dump(payload))
+        return path
+
+    def test_per_job_kind_modules_beat_top_level(self, tmp_path):
+        config = self.write_config(
+            tmp_path,
+            {
+                "job_defaults": {"jaxtrain": {"modules": ["python", "gcc", "cuda"]}},
+                "modules": ["python", "gcc"],
+            },
+        )
+        resources = resolve_resources("jaxtrain", config, {})
+        assert resources["modules"] == ["python", "gcc", "cuda"]
+
+    def test_empty_list_disables_module_loading(self, tmp_path):
+        config = self.write_config(tmp_path, {"modules": []})
+        assert resolve_resources("generate", config, {})["modules"] == []
+
+    def test_empty_modules_emits_no_module_load_lines(self, model_config, tmp_path):
+        config = self.write_config(tmp_path, {"modules": []})
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--cluster-config",
+                str(config),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = next((out / "runs").glob("*.sh")).read_text()
+        assert "module load" not in script
+
+    def test_absent_modules_key_uses_defaults(self, tmp_path):
+        config = self.write_config(tmp_path, {"job_defaults": {}})
+        assert resolve_resources("generate", config, {})["modules"] == ["python", "gcc"]
+
+
+class TestResourceValidation:
+    def test_sexagesimal_time_is_rejected_with_a_hint(self, tmp_path):
+        # PyYAML (YAML 1.1) loads unquoted 12:00:00 as the integer 43200,
+        # which SLURM would read as 43200 MINUTES.
+        config = tmp_path / "cluster.yaml"
+        config.write_text("job_defaults:\n  generate:\n    time: 12:00:00\n")
+        with pytest.raises(typer.BadParameter) as excinfo:
+            resolve_resources("generate", config, {})
+        assert "43200" in str(excinfo.value)
+        assert "12:00:00" in str(excinfo.value)  # the quoted form to use
+
+    @pytest.mark.parametrize(
+        "value", ["30", "4:00", "12:00:00", "1-00", "2-06:30", "1-00:00:00"]
+    )
+    def test_valid_slurm_time_forms_accepted(self, value, tmp_path):
+        config = tmp_path / "cluster.yaml"
+        config.write_text(f'job_defaults:\n  generate:\n    time: "{value}"\n')
+        assert resolve_resources("generate", config, {})["time"] == value
+
+
+class TestLogLevel:
+    def test_lowercase_log_level_works(self, model_config, tmp_path):
+        # The driver passes the same log-level string to both this tool and
+        # the worker CLI; a TypeError traceback here would leave the driver
+        # with no JSON line to parse.
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--script-only",
+                "--log-level",
+                "info",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert last_json_line(result.output)["job_id"] is None
+
+    def test_invalid_log_level_is_a_clean_error(self, model_config, tmp_path):
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--script-only",
+                "--log-level",
+                "VERBOSE",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "Unknown log level" in result.output
+
+
+@pytest.fixture(autouse=True)
+def _no_cwd_litter(tmp_path, monkeypatch):
+    """Every test runs from a scratch CWD; assert nothing is written there."""
+    monkeypatch.chdir(tmp_path)
+    yield
+    stray = [p for p in tmp_path.iterdir() if p.suffix in (".sh", ".out", ".err")]
+    assert not stray, f"artifacts leaked into CWD: {stray}"

--- a/using_mlflow.md
+++ b/using_mlflow.md
@@ -289,24 +289,37 @@ uv run sbatch_scripts/gen_sbatch.py generate \
     --config-path configs/examples/data_generation.yaml \
     --output-path /shared/data/output \
     --n-jobs-in-array 10 \
-    --partition gpu \
-    --num-gpus 1
+    --cluster-config configs/cluster/oscar.yaml
 
-# Output shows:
-# ============================================================
-# DATA GENERATION EXPERIMENT ID: 123456789
-# Use this ID with training commands via --data-generation-experiment-id
-# ============================================================
+# Every invocation prints exactly one JSON line on stdout (logging goes to
+# stderr, so this holds at any --log-level). It is the machine-readable
+# handle on the submission:
+# {"command": "generate --config-path ...", "job_id": 9876543,
+#  "mlflow_experiment_id": "123456789", "mlflow_run_id": null,
+#  "sbatch_script": "/shared/data/output/runs/20260809T101500_ddm_generate_sbatch.sh",
+#  "output_path": "/shared/data/output", "account": "carney-frankmj-condo",
+#  "partition": "batch"}
+#
+# Capture the experiment id for the training step:
+EXPERIMENT_ID=$(uv run sbatch_scripts/gen_sbatch.py generate ... | jq -r .mlflow_experiment_id)
+# and the SLURM job id, e.g. to chain with --dependency=afterok:$JOB_ID.
 
 # 2. Train network (after data generation completes)
 uv run sbatch_scripts/gen_sbatch.py jaxtrain \
     --config-path configs/examples/network_training_lan.yaml \
     --output-path /shared/networks/output \
     --training-data-folder /shared/data/output/training_data/lan/.../ddm \
-    --data-generation-experiment-id 123456789 \
-    --partition gpu \
-    --num-gpus 1
+    --data-generation-experiment-id "$EXPERIMENT_ID" \
+    --cluster-config configs/cluster/oscar.yaml
 ```
+
+Note the absolute `sqlite:////...` tracking URI above. A relative URI
+(`sqlite:///mlflow.db`) resolves against each process's working directory, so
+the submitting process and the compute-node workers would end up writing to
+different databases. `gen_sbatch` absolutizes a relative sqlite URI before
+embedding it in the generated script, but setting an absolute one explicitly
+is clearer — and on a shared filesystem it is what makes the runs land in one
+coherent store.
 
 ### Example 3: Viewing Results
 

--- a/uv.lock
+++ b/uv.lock
@@ -852,6 +852,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -989,6 +998,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -1000,7 +1010,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.1,<0.16" }]
+dev = [
+    { name = "pytest", specifier = ">=8.3.1" },
+    { name = "ruff", specifier = ">=0.15.1,<0.16" },
+]
 
 [[package]]
 name = "lanfactory"
@@ -1746,6 +1759,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pox"
 version = "0.3.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1938,6 +1960,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

PR-1.1 of the laptop→Oscar pipeline workstream, and the first Phase-1 piece. Makes `gen_sbatch.py` something a driver on the laptop can actually steer over ssh, and adds the cluster-resource machinery the rest of Phase 1 builds on.

The orchestrator previously swallowed sbatch failures, discarded job ids, printed the chaining experiment id at a log level that is suppressed by default, and overwrote its script in the current directory.

### Submission integrity

- **Job ids and exit codes.** `sbatch` output is parsed for the job id; a failed submission (nonzero exit, missing binary, unparseable output) exits non-zero instead of logging and returning success.
- **One JSON line on stdout, at any log level** — logging goes to stderr, so stdout carries only this:
  ```json
  {"command": "...", "job_id": 9876543, "mlflow_experiment_id": "42", "mlflow_run_id": null,
   "sbatch_script": "/out/runs/20260809T101500_ddm_generate_sbatch.sh", "output_path": "/out",
   "account": "carney-frankmj-condo", "partition": "batch"}
  ```
  This is the driver's API: `jq -r .job_id` to poll `sacct`, `jq -r .mlflow_experiment_id` to chain into training. It also fixes the suppressed-experiment-id problem — the old banner only appeared at `INFO`.
- **Scripts and SLURM logs** go to `<output-path>/runs/`, timestamped, instead of a fixed name in CWD that each invocation overwrote.
- **`--script-only` is side-effect-free**: no MLflow experiment, no orphan run, no MLflow wiring in the emitted script.
- **`--n-files` passthrough.**

### Correctness fixes found by review (each has a regression test)

- **Shell injection in the generated script.** The model name comes from a user-supplied pipeline YAML and flows into `--mlflow-run-name`. That value must keep expanding `$SLURM_ARRAY_TASK_ID`, but blanket double-quoting also leaves backticks, `$(...)` and every other `$VAR` live to bash. A model named with backticks would run a command on the compute node — reproduced live. Now the value is split into segments: only `ALLOWED_SHELL_VARS` are emitted bare, everything else goes through `shlex.quote`. Six hostile inputs are tested by asking a real `bash` what argument the job would receive.
- **The generated script did not run outside the checkout.** SLURM starts a job in the sbatch submission directory, and the script has no `cd`, so `python -m uv run generate` from `$HOME` fails with `Failed to spawn: generate` — or, worse, silently resolves a foreign `pyproject.toml`. This bites exactly the workflow the JSON contract enables (driver submits `ssh oscar sbatch /path/script.sh`). The script now pins the project with `cd <checkout> || exit 1`.
- **Relative sqlite MLflow URI.** `sqlite:///mlflow.db` resolves against each process's CWD, so the submitting process created the experiment in one database while workers wrote to another — the `mlflow_experiment_id` in the JSON would point at a file no worker ever touched, and lineage would be silently empty. Relative sqlite URIs are now absolutized before use and before embedding.
- **`--log-level info` crashed** with `TypeError: Level not an integer` before printing the JSON line, because `getattr(logging, "info")` returns the function. Now case-insensitive with a clean error for unknown levels.
- **`#SBATCH --output/--error`** paths are now quoted; SLURM splits directive lines on whitespace and these paths are user-supplied.

### Cluster resource inventory

`--cluster-config` reads per-job-kind defaults (account, partition, cores, mem, GPUs, wall time, modules) from a cluster inventory; precedence is built-in fallbacks < config < explicit CLI flags. [`configs/cluster/oscar.yaml`](configs/cluster/oscar.yaml) establishes the schema — condos with partitions/limits/`suited_for`, plus `job_defaults` per job kind.

**The values in it are placeholders marked `verified: false`.** They get seeded from a live snapshot (`sacctmgr show associations`, `sinfo`, `scontrol show partition`) in a follow-up; nothing here was invented from memory. The structure is what this PR is committing to.

Two schema details worth knowing:
- A per-job-kind `modules` list beats the top-level one (specific over generic), and `modules: []` means "load no modules", distinct from omitting the key.
- Unquoted `time: 12:00:00` in YAML 1.1 loads as the integer **43200**, which SLURM reads as 43200 *minutes* — a 60x wall-time request. This is now rejected at generation time with a message naming the quoted form.

## Tests

The repo's first pytest suite: **46 tests**, added to CI alongside the existing lint and end-to-end steps. Coverage: quoting (including injection via a real bash subprocess, and that `$VAR` in ordinary params stays literal), job-id parsing and every failure mode, the JSON contract shape at default log level and on failure, `--script-only` purity asserted against a live sqlite file, resource precedence, modules semantics, wall-time validation, and a fixture asserting no artifact ever lands in CWD.

## Commands run

```
uv run pytest tests/ -q          # 46 passed
uv run ruff check . && uv run ruff format --check .
bash local_test_run.sh           # end-to-end green (the CI e2e job)
```
Also replicated CI's `--script-only` step verbatim and inspected the emitted bash.

## Review provenance

Adversarially reviewed by a multi-agent pass over three lenses (code correctness, stale docs/callers, cluster-runtime behavior of the generated scripts), 15 findings, each independently verified. Four verifiers were interrupted; I reproduced those four myself rather than assuming them refuted — two turned out to be real and are fixed here (the `cd` blocker and the sqlite URI), along with two additional bugs found during that reproduction (`--log-level`, YAML sexagesimal).

## Docs

`using_mlflow.md` documented the deleted experiment-id banner as *the* mechanism for chaining datagen into training; it now documents the JSON line. `README.md` gains the `runs/` layout, the JSON contract, and `--cluster-config`; `configs/README.md` documents the cluster-config schema and precedence. Both `sample_*_sbatch.sh` are regenerated from the current generator.

## Known, not addressed here

- With `n_jobs_in_array` in the tens or hundreds, all workers write to one sqlite file on shared storage; SQLite locking over GPFS can produce intermittent "database is locked" errors. The documented escape hatch is an `mlflow server` URI (no code change needed). Tracked for Phase 2.
- If MLflow initialization fails, submission proceeds with an untracked job. That is pre-existing behavior, and it is now *detectable* by the driver: `mlflow_experiment_id` comes back `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cluster configuration support for resource selection, modules, validation, and job-specific defaults.
  - Added configurable file counts and resource overrides for generation and training commands.
  - Improved job submission reporting with structured JSON output, job IDs, failure handling, and timestamped run artifacts.
  - Added safer script generation and clearer script-only behavior.

- **Documentation**
  - Expanded setup and cluster workflow documentation, including MLflow usage and configuration precedence.

- **Tests**
  - Added comprehensive automated coverage and CI execution for the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->