### PR TITLE
Scheduled drift detection: frozen-lock regression + weekly lock-upgrade probe

### DIFF
--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -25,6 +25,14 @@ on:
 permissions:
   contents: read
 
+# Whole-run, not just the report job: serializing only the reports still lets a
+# newer failing run file the issue before an older green run reaches its report,
+# which would then close it. cancel-in-progress: false so nothing is lost —
+# a queued run waits rather than dying.
+concurrency:
+  group: drift-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   as-committed:
     permissions:
@@ -57,9 +65,11 @@ jobs:
       - name: Re-lock against current upstreams
         run: uv lock --upgrade
 
+      # --frozen: fail loudly if anything would re-lock, so the artifact
+      # uploaded below is byte-identical to the lock that was just tested.
       - name: Install and test on the upgraded lock
         run: |
-          uv sync
+          uv sync --frozen
           uv run pytest tests/ -q
           bash local_test_run.sh
 
@@ -80,9 +90,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-    concurrency:
-      group: drift-issue-${{ github.repository }}
-      cancel-in-progress: false
     steps:
       - name: Create, update, or close the deduped drift issue
         env:

--- a/.github/workflows/drift.yml
+++ b/.github/workflows/drift.yml
@@ -1,0 +1,142 @@
+name: Drift
+
+# This repo has the ecosystem's inverse drift problem. Everywhere else there
+# is no lockfile, so CI re-resolves on every run and upstream breakage shows
+# up on its own. Here uv.lock is committed AND pins ssm-simulators/lanfactory
+# to git commits, so `uv sync --frozen` is perfectly reproducible — and stays
+# perfectly reproducible while both upstreams move on without us. Nothing
+# fails; the pin just quietly ages.
+#
+# So the weekly run asks two different questions:
+#   as-committed  — does the frozen lock still work? (runner/OS/action drift)
+#   lock-upgrade  — would today's upstreams still work? (the real signal)
+# Only `as-committed` gates the drift issue. lock-upgrade failing means
+# "upgrading is not free yet", which is information, not breakage.
+on:
+  schedule:
+    - cron: "30 5 * * 1" # weekly, staggered after the sibling repos
+  workflow_dispatch:
+    inputs:
+      force_fail:
+        description: "Exercise the drift-issue path without a real failure"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  as-committed:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/run_tests.yml
+
+  lock-upgrade:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install GSL (for the ssm-simulators build)
+        run: sudo apt-get update && sudo apt-get install -y libgsl-dev
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      # The whole point: re-resolve instead of --frozen, so the git-pinned
+      # upstreams advance to their current main.
+      - name: Re-lock against current upstreams
+        run: uv lock --upgrade
+
+      - name: Install and test on the upgraded lock
+        run: |
+          uv sync
+          uv run pytest tests/ -q
+          bash local_test_run.sh
+
+      # The healer downloads this instead of re-deriving the upgrade, so the
+      # PR it opens is exactly the lock that just passed.
+      - name: Upload the upgraded lockfile
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: uv-lock-upgraded
+          path: uv.lock
+          retention-days: 30
+
+  report:
+    needs: [as-committed, lock-upgrade]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: drift-issue-${{ github.repository }}
+      cancel-in-progress: false
+    steps:
+      - name: Create, update, or close the deduped drift issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT_COMMITTED: ${{ needs['as-committed'].result }}
+          FORCE_FAIL: ${{ inputs.force_fail }}
+        run: |
+          set -euo pipefail
+          KEY="drift-key: LAN_pipeline_minimal-scheduled"
+          TITLE="drift: LAN_pipeline_minimal scheduled checks failing"
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
+          # Only as-committed gates the issue: a failing lock-upgrade means the
+          # upgrade isn't free yet, which the budget tracks separately. And
+          # `cancelled` is never evidence of health — this job runs under
+          # `if: always()`, so treating it as green would close a real issue.
+          FAILED_JOBS=""
+          [ "$RESULT_COMMITTED" = "failure" ] && FAILED_JOBS=" as-committed"
+          if [ "$FORCE_FAIL" = "true" ]; then
+            FAILED_JOBS="$FAILED_JOBS (force_fail rehearsal)"
+          fi
+
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --label drift \
+            --state open --search "in:body \"$KEY\"" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "$FAILED_JOBS" ]; then
+            if [ "$RESULT_COMMITTED" = "success" ]; then
+              if [ -n "$EXISTING" ]; then
+                gh issue close "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+                  --comment "Scheduled drift checks green again: $RUN_URL"
+              fi
+            else
+              echo "::notice::Inconclusive run (as-committed: $RESULT_COMMITTED)" \
+                "— drift issue state left unchanged."
+            fi
+            exit 0
+          fi
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" \
+              --body "Still failing (${FAILED_JOBS# }): $RUN_URL"
+          else
+            gh label create drift --repo "$GITHUB_REPOSITORY" \
+              --description "scheduled drift detection failure" \
+              --force 2>/dev/null || true
+            BODY=$(printf '%s\n' \
+              "<!-- $KEY -->" \
+              "Scheduled drift run failed in:${FAILED_JOBS}" \
+              "Run: $RUN_URL" \
+              "" \
+              "\`as-committed\` re-runs the suite on the committed uv.lock, so a failure here is runner/OS/action drift rather than an upstream release — the lock pins ssm-simulators and lanfactory to fixed git commits." \
+              "Check the \`lock-upgrade\` job in the same run: if it passed, its \`uv-lock-upgraded\` artifact is a tested lockfile ready to PR." \
+              "Triage via the spine's audit-drift skill.")
+            gh issue create --repo "$GITHUB_REPOSITORY" --label drift \
+              --title "$TITLE" --body "$BODY"
+          fi

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_call: # drift.yml (scheduled frozen-lock regression)
 
 permissions:
   contents: read


### PR DESCRIPTION
Last of the five repos in the drift-detection rollout, unblocked by #24. Same shape as the siblings (ssm-simulators#318, LANfactory#107, HSSM#1143, HSSMCortex#2), but this repo has the **inverse** problem, so the workflow asks a different question.

Everywhere else there's no lockfile: CI re-resolves every run, so an upstream release breaks us loudly and on its own. Here `uv.lock` is committed *and* pins ssm-simulators and lanfactory to git commits, so `uv sync --frozen` is perfectly reproducible — and stays perfectly reproducible while both upstreams move on without us. Nothing ever fails. The pin just quietly ages.

Two jobs, two questions:

- **`as-committed`** — does the frozen lock still work? Calls the existing `run_tests.yml` (now `workflow_call`-able). A failure here is runner/OS/action drift, not an upstream release, and the issue body says so to save the triage step.
- **`lock-upgrade`** — would *today's* upstreams still work? `uv lock --upgrade`, sync, unit tests, and the end-to-end `local_test_run.sh`. On success it uploads the upgraded `uv.lock` as an artifact, so the healing PR ships exactly the lockfile that just passed rather than re-deriving it.

**Only `as-committed` gates the drift issue.** A red `lock-upgrade` means "upgrading isn't free yet" — real information, tracked by its own `lan-pipeline-lock-upgrade` freshness budget, but not a reason to open a breakage issue.

Carries the fixes the sibling PRs earned in review:

- `cancelled` never counts as green (the report job runs under `if: always()`, which includes cancellation, so treating it as success would silently close a real issue)
- `issues: write` scoped to the `report` job, so the token that installs third-party packages and runs the pipeline stays read-only
- job-level `concurrency` around the non-atomic issue read/write
- `needs['as-committed'].result` in bracket form — a hyphen in a job id parses as subtraction

Cron is `30 5 * * 1`, staggered after the siblings.

**Post-merge:** dispatch once with `force_fail=true` to exercise the issue path, then a real dispatch to confirm close-on-green — same rehearsal the other four passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduled and manually triggered dependency drift checks.
  - Added automated testing for committed and upgraded dependency locks.
  - Added reporting that creates, updates, and closes drift issues with run details and artifacts.
  - Enabled the test workflow to be reused by other automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->