### PR TITLE
Discover each user's cluster lanes, and use all of them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Per-user cluster lanes written by scripts/discover_cluster.py.
+# Personal allocations and paths never belong in the repo.
+configs/cluster/*.local.yaml

--- a/configs/README.md
+++ b/configs/README.md
@@ -110,6 +110,93 @@ Every entry carries `verified_on`, the date it was last read off the cluster
 the real per-user caps live in the **QOS**, not the partition: `scontrol show
 partition` reports `MaxTime=UNLIMITED` for batch, gpu and gpu-he alike.
 
+## Personalising: two files, one committed, one not
+
+Cluster config is split by *who it is true for*:
+
+| file | committed? | holds |
+|------|-----------|-------|
+| `cluster/oscar.yaml` | yes | the cluster and the lab's condo: partitions, QOS caps, node inventory, modules, per-job-kind resources — identical for every member |
+| `cluster/oscar.local.yaml` | **no** (gitignored) | *your* associations, lane caps and choices |
+
+`gen_sbatch` merges the local file over the committed one automatically
+whenever you pass `--cluster-config .../oscar.yaml`; there is no second flag.
+Precedence end to end:
+
+```
+built-in fallbacks  <  oscar.yaml  <  oscar.local.yaml  <  explicit CLI flags
+```
+
+That is why no path, quota or account of yours needs to be committed to share
+this repo with the rest of the lab.
+
+### Step 1 — discover what you can actually schedule
+
+```bash
+# from a login node
+uv run python scripts/discover_cluster.py
+
+# or from a laptop, through your ssh config entry
+uv run python scripts/discover_cluster.py --ssh-host oscar
+```
+
+It asks SLURM which associations you hold and what each one's QOS allows, then
+writes `configs/cluster/oscar.local.yaml`. Output looks like:
+
+```
+Found 4 lanes:
+  <your-condo>               batch      qos=<condo-qos>   priority=10000  208 cores
+  <your-condo>               gpu-he     qos=<condo-gqos>  priority=10000  160 cores, 75 gpus
+  default                    batch      qos=normal        priority=0      64 cores
+  default                    gpu        qos=norm-gpu      priority=0      12 cores, 2 gpus
+  -> 272 CPU cores usable for datagen across 2 lane(s)
+```
+
+Re-run it whenever your allocations change. Never hand-edit the generated file
+— it is overwritten, and hand-edits are exactly the personal values that used
+to leak into the repo.
+
+**Why discovery rather than documentation:** the numbers that matter are
+`MaxTRESPU` on the *QOS*, and nothing else surfaces them. `scontrol show
+partition` reports `MaxTime=UNLIMITED` for every partition on this cluster, so
+reading partition limits tells you nothing.
+
+### Step 2 — use every lane you have
+
+A **lane** is one (account, partition) pair you may submit to. SLURM applies
+each QOS's cap *per QOS*, so two lanes are two independent budgets and their
+capacity genuinely adds up. `--use-all-lanes` splits an array across them in
+proportion to their core caps:
+
+```bash
+uv run python sbatch_scripts/gen_sbatch.py generate \
+    --config-path configs/examples/data_generation.yaml \
+    --output-path "$LAN_PIPELINE_ROOT/data" \
+    --cluster-config configs/cluster/oscar.yaml \
+    --n-jobs-in-array 100 \
+    --use-all-lanes
+```
+
+```json
+{"lane": 0, "n_lanes": 2, "account": "<your-condo>", "array_size": 77, "job_id": 9876543, ...}
+{"lane": 1, "n_lanes": 2, "account": "default",      "array_size": 23, "job_id": 9876544, ...}
+```
+
+One JSON line per lane. Without the flag you get exactly one line and one
+submission, as before — fan-out is opt-in because it changes how many jobs
+land on the cluster.
+
+**Read the priorities before relying on this.** A condo lane typically has
+priority 10000 and the general `default` lane has 0, so spillover tasks queue
+behind everyone else's work. Treat the extra lanes as *opportunistic* capacity
+— excellent for an overnight sweep, unreliable when you need results in an
+hour. If any lane fails to submit, the command exits non-zero and the JSON
+lines tell you which ones did land.
+
+Training is deliberately **not** fanned out: a single job cannot use two lanes,
+so discovery maps `jaxtrain`/`torchtrain` onto one GPU on your highest-priority
+GPU lane instead.
+
 ## Where things go on Oscar
 
 The cluster config deliberately holds **no paths** — paths are per-person, the

--- a/sbatch_scripts/gen_sbatch.py
+++ b/sbatch_scripts/gen_sbatch.py
@@ -195,6 +195,59 @@ def create_command(command_name: str, **params) -> str:
     return " ".join(parts)
 
 
+def load_cluster_config(cluster_config_path: Path) -> dict:
+    """The committed cluster config, with the per-user file merged over it.
+
+    `<name>.yaml` holds facts that are the same for the whole lab; the
+    gitignored `<name>.local.yaml` beside it holds one person's associations,
+    caps and lanes, written by scripts/discover_cluster.py. Merging here means
+    nobody has to remember to pass a second flag, and no personal value ever
+    needs to be committed.
+    """
+    with open(cluster_config_path, "rb") as f:
+        config = yaml.safe_load(f) or {}
+
+    local_path = cluster_config_path.with_suffix(".local.yaml")
+    if not local_path.exists():
+        return config
+
+    with open(local_path, "rb") as f:
+        local = yaml.safe_load(f) or {}
+    for key, value in local.items():
+        if key == "job_defaults" and isinstance(value, dict):
+            merged = dict(config.get("job_defaults") or {})
+            for kind, overrides in value.items():
+                merged[kind] = {**(merged.get(kind) or {}), **(overrides or {})}
+            config["job_defaults"] = merged
+        else:
+            config[key] = value
+    return config
+
+
+def split_across_lanes(lanes: list[dict], n_jobs: int) -> list[tuple[dict, int]]:
+    """Divide an array job across lanes in proportion to their core caps.
+
+    Each lane's cap is a separate SLURM budget, so the capacity really adds up
+    — but lanes differ in priority, and a low-priority lane may sit in the
+    queue. Bigger, higher-priority lanes therefore get proportionally more of
+    the array, and the remainder goes to the best lane.
+    """
+    usable = [x for x in lanes if x.get("max_cores")]
+    if len(usable) < 2 or n_jobs < 2:
+        return [(lanes[0] if lanes else {}, n_jobs)]
+
+    ordered = sorted(usable, key=lambda x: (-x.get("priority", 0), -x["max_cores"]))
+    total = sum(x["max_cores"] for x in ordered)
+    shares = [max(1, n_jobs * x["max_cores"] // total) for x in ordered]
+
+    # Trim or pad to land exactly on n_jobs, always adjusting the best lane.
+    while sum(shares) > n_jobs:
+        biggest = shares.index(max(shares))
+        shares[biggest] -= 1
+    shares[0] += n_jobs - sum(shares)
+    return [(lane, size) for lane, size in zip(ordered, shares) if size > 0]
+
+
 def resolve_resources(
     command_name: str,
     cluster_config_path: Path | None,
@@ -214,11 +267,10 @@ def resolve_resources(
     modules = list(DEFAULT_MODULES)
 
     if cluster_config_path is not None:
-        with open(cluster_config_path, "rb") as f:
-            cluster_config = yaml.safe_load(f) or {}
+        cluster_config = load_cluster_config(cluster_config_path)
         job_defaults = (cluster_config.get("job_defaults") or {}).get(command_name, {})
 
-        known = set(resolved) | {"modules"}
+        known = set(resolved) | {"modules", "lanes"}
         unknown = set(job_defaults) - known
         if unknown and logger is not None:
             logger.warning(
@@ -226,6 +278,8 @@ def resolve_resources(
                 f"{cluster_config_path}: {sorted(unknown)}"
             )
         resolved.update({k: v for k, v in job_defaults.items() if k in resolved})
+        if job_defaults.get("lanes"):
+            resolved["lanes"] = job_defaults["lanes"]
 
         # Presence, not truthiness: `modules: []` disables module loading.
         if "modules" in cluster_config:
@@ -443,6 +497,7 @@ def handle_job(
     cluster_config: Path = None,
     n_jobs_in_array: int = 1,
     n_files: int = None,
+    use_all_lanes: bool = False,
     training_data_folder: Path = None,
     network_id: int = 0,
     dl_workers: int = 1,
@@ -624,25 +679,8 @@ def handle_job(
         except Exception as e:
             logger.error(f"Failed to initialize MLflow: {e}")
 
-    params = get_parameters_setup(
-        command=command_name,
-        config_path=config_path,
-        output_path=output_path,
-        log_level=log_level,
-        training_data_folder=training_data_folder,
-        network_id=network_id,
-        dl_workers=dl_workers,
-        mlflow_run_name=mlflow_run_name,
-        mlflow_experiment_name=mlflow_experiment_name,
-        mlflow_run_id=mlflow_run_id,
-        data_generation_experiment_id=data_generation_experiment_id,
-    )
-    if command_name == "generate" and n_files is not None:
-        params["n-files"] = n_files
-    command = create_command(command_name, **params)
-    logger.info(f"Generated command: {command}")
-    basic_config = get_basic_config_from_yaml(params["config-path"])
-    job_name = f"{safe_name(basic_config['MODEL'])}_{command_name}_sbatch"
+    basic_config = get_basic_config_from_yaml(config_path.resolve())
+    job_name_base = f"{safe_name(basic_config['MODEL'])}_{command_name}_sbatch"
 
     # Scripts and SLURM logs live under <output_path>/runs/, timestamped —
     # repeated invocations never overwrite each other (previously the script
@@ -651,60 +689,120 @@ def handle_job(
     validate_log_path(runs_dir)
     runs_dir.mkdir(exist_ok=True, parents=True)
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
-    script = runs_dir / f"{timestamp}_{job_name}.sh"
 
-    sbatch_kwargs = dict(
-        account=resources["account"],
-        partition=resources["partition"],
-        num_gpus=resources["num_gpus"],
-        cores=resources["cores"],
-        mem=resources["mem"],
-        job_name=job_name,
-        # %A_%a = array job id + task index. The template always emits
-        # --array, so every task would otherwise append to one shared pair of
-        # files and interleave its output with the others'.
-        output=str(runs_dir / f"{job_name}_%A_%a.out"),
-        error=str(runs_dir / f"{job_name}_%A_%a.err"),
-        time=resources["time"],
-        command=command,
-        n_jobs_in_array=n_jobs_in_array,
-        env_vars=env_vars,
-        modules=resources["modules"],
-    )
-    sbatch_script = create_sbatch_script(**sbatch_kwargs)
-    write_sbatch(script, sbatch_script)
+    # One submission per lane. A lane is an (account, partition) pair whose
+    # SLURM budget is independent of the others', so splitting an array across
+    # lanes really does buy extra parallelism — see split_across_lanes.
+    if use_all_lanes and resources.get("lanes"):
+        plan = split_across_lanes(resources["lanes"], n_jobs_in_array)
+    else:
+        plan = [({}, n_jobs_in_array)]
+    fanned_out = len(plan) > 1
 
-    # The one machine-readable line on stdout, regardless of log level: the
-    # laptop driver's API. Logging goes to stderr, so stdout carries only this.
-    result_record = {
-        "command": command,
-        "job_id": None,
-        "mlflow_experiment_id": mlflow_experiment_id,
-        "mlflow_run_id": mlflow_run_id,
-        "sbatch_script": str(script),
-        "output_path": str(target),
-        "account": resources["account"],
-        "partition": resources["partition"],
-    }
+    if fanned_out:
+        logger.warning(
+            f"Fanning {n_jobs_in_array} array tasks across {len(plan)} lanes: "
+            + ", ".join(
+                f"{lane.get('account')}/{lane.get('partition')}={size}"
+                for lane, size in plan
+            )
+        )
+
+    failures = 0
+    for index, (lane, array_size) in enumerate(plan):
+        account = lane.get("account", resources["account"])
+        partition = lane.get("partition", resources["partition"])
+
+        lane_run_name = mlflow_run_name
+        if fanned_out and mlflow_run_name:
+            # Two arrays both number their tasks from 1, so without the lane
+            # index the MLflow run names would collide across lanes.
+            lane_run_name = mlflow_run_name.replace("-worker-", f"-worker-l{index}-")
+
+        params = get_parameters_setup(
+            command=command_name,
+            config_path=config_path,
+            output_path=output_path,
+            log_level=log_level,
+            training_data_folder=training_data_folder,
+            network_id=network_id,
+            dl_workers=dl_workers,
+            mlflow_run_name=lane_run_name,
+            mlflow_experiment_name=mlflow_experiment_name,
+            mlflow_run_id=mlflow_run_id,
+            data_generation_experiment_id=data_generation_experiment_id,
+        )
+        if command_name == "generate" and n_files is not None:
+            params["n-files"] = n_files
+        command = create_command(command_name, **params)
+        logger.info(f"Generated command: {command}")
+
+        job_name = f"{job_name_base}_l{index}" if fanned_out else job_name_base
+        script = runs_dir / f"{timestamp}_{job_name}.sh"
+
+        sbatch_script = create_sbatch_script(
+            account=account,
+            partition=partition,
+            num_gpus=resources["num_gpus"],
+            cores=resources["cores"],
+            mem=resources["mem"],
+            job_name=job_name,
+            # %A_%a = array job id + task index. The template always emits
+            # --array, so every task would otherwise append to one shared pair
+            # of files and interleave its output with the others'.
+            output=str(runs_dir / f"{job_name}_%A_%a.out"),
+            error=str(runs_dir / f"{job_name}_%A_%a.err"),
+            time=resources["time"],
+            command=command,
+            n_jobs_in_array=array_size,
+            env_vars=env_vars,
+            modules=resources["modules"],
+        )
+        write_sbatch(script, sbatch_script)
+
+        # One machine-readable line per submission, regardless of log level:
+        # the laptop driver's API. Logging goes to stderr, so stdout carries
+        # only these. A single-lane run emits exactly one line, as before.
+        result_record = {
+            "command": command,
+            "job_id": None,
+            "mlflow_experiment_id": mlflow_experiment_id,
+            "mlflow_run_id": mlflow_run_id,
+            "sbatch_script": str(script),
+            "output_path": str(target),
+            "account": account,
+            "partition": partition,
+            "array_size": array_size,
+            "lane": index,
+            "n_lanes": len(plan),
+        }
+
+        if script_only:
+            logger.info(f"Generated sbatch script: {script}")
+            print(json.dumps(result_record))
+            continue
+
+        job_id = submit_sbatch(script, logger)
+        result_record["job_id"] = job_id
+        print(json.dumps(result_record))
+        if job_id is None:
+            failures += 1
+
+    if MLFLOW_AVAILABLE and mlflow.active_run():
+        mlflow.end_run()
 
     if script_only:
-        logger.info(f"Generated sbatch script: {script}")
-        print(json.dumps(result_record))
         return
 
     if command_name == "generate":
         logger.info(f"Simulated data output folder: {target}")
     else:
         logger.info(f"Trained networks output folder: {target}")
-    job_id = submit_sbatch(script, logger)
-    result_record["job_id"] = job_id
 
-    if MLFLOW_AVAILABLE and mlflow.active_run():
-        mlflow.end_run()
-
-    print(json.dumps(result_record))
-    if job_id is None:
-        logger.error("Job submission failed")
+    if failures:
+        # Partial success is still a failure for the caller: some lanes are
+        # running and some are not, and only the JSON lines say which.
+        logger.error(f"{failures} of {len(plan)} lane submissions failed")
         raise typer.Exit(code=1)
     logger.info("Job submitted successfully")
 
@@ -728,7 +826,19 @@ def generate(
         readable=True,
         help="Cluster inventory YAML (e.g. configs/cluster/oscar.yaml); its "
         "job_defaults section supplies account/partition/resources for this "
-        "job kind. Explicit flags below override it.",
+        "job kind. A gitignored <name>.local.yaml beside it, written by "
+        "scripts/discover_cluster.py, is merged over it. Explicit flags "
+        "below override both.",
+    ),
+    use_all_lanes: bool = typer.Option(
+        False,
+        "--use-all-lanes",
+        is_flag=True,
+        help="Split the job array across every lane in the cluster config, "
+        "proportional to each lane's core cap. Lane budgets are independent "
+        "in SLURM, so this adds capacity — but lower-priority lanes queue "
+        "longer, so treat the extra as spillover. Emits one JSON line per "
+        "lane.",
     ),
     account: str = typer.Option(
         None, help="Condo to run the SBATCH job on [default: from cluster config]"
@@ -775,6 +885,7 @@ def generate(
         mem=mem,
         n_jobs_in_array=n_jobs_in_array,
         n_files=n_files,
+        use_all_lanes=use_all_lanes,
     )
 
 

--- a/scripts/discover_cluster.py
+++ b/scripts/discover_cluster.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Ask the cluster what *this* user may actually schedule, and write it down.
+
+The committed `configs/cluster/oscar.yaml` records facts that are the same for
+everyone in the lab. What differs per person is which associations they hold and
+therefore how much they can run at once — and nobody can answer that from
+memory, because the numbers that matter live in the QOS, not the partition
+(`scontrol show partition` reports MaxTime=UNLIMITED for everything).
+
+This writes `configs/cluster/oscar.local.yaml`, which is gitignored: it is
+*your* allocation, not the lab's. `gen_sbatch` merges it over the committed
+file automatically.
+
+    # from a login node
+    uv run python scripts/discover_cluster.py
+
+    # or from a laptop, over the ssh config entry
+    uv run python scripts/discover_cluster.py --ssh-host oscar
+
+A "lane" is one (account, partition, QOS) triple you are allowed to submit to.
+Its cap is `MaxTRESPU` on the QOS, which SLURM applies *per QOS*, so two lanes
+are two independent budgets — running in both really does give you their sum.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_OUTPUT = (
+    Path(__file__).resolve().parent.parent / "configs/cluster/oscar.local.yaml"
+)
+
+
+def run(command: str, ssh_host: str | None) -> str:
+    """Run a read-only cluster query, locally or over ssh."""
+    argv = (
+        ["ssh", "-o", "BatchMode=yes", ssh_host, command]
+        if ssh_host
+        else ["bash", "-lc", command]
+    )
+    result = subprocess.run(argv, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"`{command}` failed ({result.returncode}): {result.stderr.strip()[:200]}\n"
+            + (
+                "Run this on a login node, or pass --ssh-host."
+                if ssh_host is None
+                else "Check that your ssh session is authenticated (one Duo prompt)."
+            )
+        )
+    return result.stdout
+
+
+# QOS that exist on every account but are not for pipeline work: debug queues
+# are time-boxed, vnc is for interactive desktops.
+NON_COMPUTE_QOS = {"debug", "gpu-debug", "vnc"}
+
+
+def parse_cap(tres: str) -> dict:
+    """`cpu=208,mem=2500G,gres/gpu=75` -> {'cores': 208, 'mem': '2500G', 'gpus': 75}."""
+    cap: dict = {}
+    for item in filter(None, tres.split(",")):
+        key, _, value = item.partition("=")
+        if key == "cpu":
+            cap["cores"] = int(value)
+        elif key == "mem":
+            cap["mem"] = value
+        elif key.startswith("gres/gpu"):
+            cap["gpus"] = int(value)
+    return cap
+
+
+def discover(ssh_host: str | None) -> dict:
+    associations = run(
+        "sacctmgr -nP show associations user=$USER format=Account,Partition,QOS",
+        ssh_host,
+    )
+    lanes: list[dict] = []
+    qos_names = set()
+    for line in associations.strip().splitlines():
+        fields = line.split("|")
+        if len(fields) < 3 or not fields[1]:
+            continue  # rows without a partition are the account-level parent
+        account, partition, qos = fields[0], fields[1], fields[2]
+        lanes.append({"account": account, "partition": partition, "qos": qos})
+        qos_names.add(qos)
+
+    if not lanes:
+        raise RuntimeError("No associations found — is this the right cluster account?")
+
+    qos_rows = run(
+        "sacctmgr -nP show qos where name="
+        + ",".join(sorted(qos_names))
+        + " format=Name,Priority,MaxWall,MaxTRESPU,MaxSubmitJobsPU",
+        ssh_host,
+    )
+    qos_info = {}
+    for line in qos_rows.strip().splitlines():
+        f = (line.split("|") + [""] * 5)[:5]
+        qos_info[f[0]] = {
+            "priority": int(f[1]) if f[1].isdigit() else 0,
+            "max_walltime": f[2] or None,
+            "cap": parse_cap(f[3]),
+            "max_submit_jobs": int(f[4]) if f[4].isdigit() else None,
+        }
+
+    for lane in lanes:
+        info = qos_info.get(lane["qos"], {})
+        lane["priority"] = info.get("priority", 0)
+        lane["max_walltime"] = info.get("max_walltime")
+        lane.update(info.get("cap", {}))
+        if info.get("max_submit_jobs"):
+            lane["max_submit_jobs"] = info["max_submit_jobs"]
+
+    # Best lane first: highest priority, then most cores.
+    lanes.sort(key=lambda x: (-x["priority"], -x.get("cores", 0)))
+    return {"lanes": lanes}
+
+
+def suggest_job_defaults(lanes: list[dict]) -> dict:
+    """Map the discovered lanes onto the pipeline's job kinds.
+
+    Datagen is embarrassingly parallel and CPU-bound, so it can use every CPU
+    lane at once. Training wants one GPU on the highest-priority GPU lane;
+    spilling a single training job across lanes would not help it.
+    """
+    # A usable compute lane needs a known core cap and must not be a debug or
+    # vnc queue: those exist for everyone and would inflate the totals.
+    usable = [x for x in lanes if x["qos"] not in NON_COMPUTE_QOS and x.get("cores")]
+    cpu = [x for x in usable if not x.get("gpus")]
+    gpu = [x for x in usable if x.get("gpus")]
+
+    defaults: dict = {}
+    if cpu:
+        best = cpu[0]
+        defaults["generate"] = {
+            "account": best["account"],
+            "partition": best["partition"],
+            "lanes": [
+                {
+                    "account": x["account"],
+                    "partition": x["partition"],
+                    "max_cores": x["cores"],
+                    "priority": x["priority"],
+                }
+                for x in cpu
+            ],
+        }
+    if gpu:
+        best = gpu[0]
+        for kind in ("jaxtrain", "torchtrain"):
+            defaults[kind] = {
+                "account": best["account"],
+                "partition": best["partition"],
+                "num_gpus": 1,
+            }
+    return defaults
+
+
+def to_yaml(data: dict, ssh_host: str | None) -> str:
+    import yaml
+
+    header = f"""# Per-user cluster lanes — GENERATED, gitignored, do not hand-edit.
+#
+# Written by `scripts/discover_cluster.py{" --ssh-host " + ssh_host if ssh_host else ""}`.
+# These are YOUR associations and caps; the lab-wide facts live in the
+# committed oscar.yaml, which this file is merged over.
+#
+# `cores` on each lane is MaxTRESPU from its QOS. SLURM applies that cap per
+# QOS, so separate lanes are separate budgets and their capacity adds up.
+# Re-run discovery whenever your allocations change.
+"""
+    return header + yaml.safe_dump(data, sort_keys=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--ssh-host", help="Run the queries over ssh (e.g. oscar).")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--print", action="store_true", help="Print instead of writing."
+    )
+    args = parser.parse_args()
+
+    try:
+        discovered = discover(args.ssh_host)
+    except RuntimeError as e:
+        print(f"discovery failed: {e}", file=sys.stderr)
+        return 1
+
+    lanes = discovered["lanes"]
+    discovered["job_defaults"] = suggest_job_defaults(lanes)
+
+    print(f"Found {len(lanes)} lanes:", file=sys.stderr)
+    for lane in lanes:
+        gpus = f", {lane['gpus']} gpus" if lane.get("gpus") else ""
+        print(
+            f"  {lane['account']:26s} {lane['partition']:10s} "
+            f"qos={lane['qos']:16s} priority={lane['priority']:<6d} "
+            f"{lane.get('cores', '?')} cores{gpus}",
+            file=sys.stderr,
+        )
+    cpu_lanes = [
+        x
+        for x in lanes
+        if x["qos"] not in NON_COMPUTE_QOS and x.get("cores") and not x.get("gpus")
+    ]
+    total = sum(x["cores"] for x in cpu_lanes)
+    print(
+        f"  -> {total} CPU cores usable for datagen across {len(cpu_lanes)} lane(s)\n",
+        file=sys.stderr,
+    )
+
+    text = to_yaml(discovered, args.ssh_host)
+    if args.print:
+        print(text)
+    else:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text)
+        print(f"wrote {args.output}", file=sys.stderr)
+        print(
+            "gen_sbatch picks it up automatically; check with:\n"
+            "  uv run python sbatch_scripts/gen_sbatch.py generate --help",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_gen_sbatch.py
+++ b/tests/test_gen_sbatch.py
@@ -18,6 +18,8 @@ import gen_sbatch
 from gen_sbatch import (
     absolutize_tracking_uri,
     app,
+    load_cluster_config,
+    split_across_lanes,
     create_command,
     quote_param_value,
     resolve_resources,
@@ -35,6 +37,11 @@ JSON_KEYS = {
     "output_path",
     "account",
     "partition",
+    # Added with lane fan-out. Additive: a single-lane run still emits exactly
+    # one line, with lane=0 and n_lanes=1, so existing consumers are unaffected.
+    "array_size",
+    "lane",
+    "n_lanes",
 }
 
 
@@ -705,3 +712,216 @@ def _no_cwd_litter(tmp_path, monkeypatch):
     yield
     stray = [p for p in tmp_path.iterdir() if p.suffix in (".sh", ".out", ".err")]
     assert not stray, f"artifacts leaked into CWD: {stray}"
+
+
+CONDO = {"account": "my-condo", "partition": "batch", "max_cores": 208, "priority": 10000}
+SPILL = {"account": "default", "partition": "batch", "max_cores": 64, "priority": 0}
+
+
+class TestLaneSplit:
+    def test_splits_in_proportion_to_core_caps(self):
+        plan = split_across_lanes([CONDO, SPILL], 100)
+        assert [(lane["account"], size) for lane, size in plan] == [
+            ("my-condo", 77),
+            ("default", 23),
+        ]
+
+    @pytest.mark.parametrize("n_jobs", [2, 3, 5, 7, 10, 33, 100, 501])
+    def test_every_task_is_allocated_exactly_once(self, n_jobs):
+        plan = split_across_lanes([CONDO, SPILL], n_jobs)
+        assert sum(size for _, size in plan) == n_jobs
+        assert all(size > 0 for _, size in plan)
+
+    def test_highest_priority_lane_leads(self):
+        # Passed worst-first; the split must still favour the condo.
+        plan = split_across_lanes([SPILL, CONDO], 100)
+        assert plan[0][0]["account"] == "my-condo"
+        assert plan[0][1] > plan[1][1]
+
+    def test_a_single_task_does_not_fan_out(self):
+        # Splitting one task across two lanes would just add queue latency.
+        assert len(split_across_lanes([CONDO, SPILL], 1)) == 1
+
+    def test_lanes_without_a_cap_are_ignored(self):
+        plan = split_across_lanes([CONDO, {"account": "vnc", "partition": "vnc"}], 10)
+        assert len(plan) == 1
+
+
+class TestLocalConfigLayering:
+    def write(self, path, payload):
+        import yaml as _yaml
+
+        path.write_text(_yaml.safe_dump(payload))
+        return path
+
+    def test_local_file_merges_over_the_committed_one(self, tmp_path):
+        shared = self.write(
+            tmp_path / "oscar.yaml",
+            {
+                "job_defaults": {"generate": {"account": "lab-condo", "cores": 1}},
+                "modules": ["python", "gcc"],
+            },
+        )
+        self.write(
+            tmp_path / "oscar.local.yaml",
+            {"job_defaults": {"generate": {"account": "my-condo", "lanes": [CONDO]}}},
+        )
+        merged = load_cluster_config(shared)
+        generate = merged["job_defaults"]["generate"]
+        assert generate["account"] == "my-condo"  # personal wins
+        assert generate["cores"] == 1  # shared survives
+        assert generate["lanes"] == [CONDO]
+        assert merged["modules"] == ["python", "gcc"]
+
+    def test_absent_local_file_is_not_an_error(self, tmp_path):
+        shared = self.write(tmp_path / "oscar.yaml", {"modules": ["python"]})
+        assert load_cluster_config(shared)["modules"] == ["python"]
+
+    def test_local_lanes_reach_the_resolver(self, tmp_path):
+        shared = self.write(
+            tmp_path / "oscar.yaml", {"job_defaults": {"generate": {"cores": 2}}}
+        )
+        self.write(
+            tmp_path / "oscar.local.yaml",
+            {"job_defaults": {"generate": {"lanes": [CONDO, SPILL]}}},
+        )
+        resources = resolve_resources("generate", shared, {})
+        assert len(resources["lanes"]) == 2
+        assert resources["cores"] == 2
+
+
+class TestFanOut:
+    def cluster_files(self, tmp_path, lanes):
+        import yaml as _yaml
+
+        shared = tmp_path / "oscar.yaml"
+        shared.write_text(
+            _yaml.safe_dump(
+                {
+                    "job_defaults": {
+                        "generate": {
+                            "account": "lab-condo",
+                            "partition": "batch",
+                            "cores": 1,
+                            "mem": "16G",
+                            "num_gpus": 0,
+                            "time": "04:00:00",
+                        }
+                    }
+                }
+            )
+        )
+        (tmp_path / "oscar.local.yaml").write_text(
+            _yaml.safe_dump({"job_defaults": {"generate": {"lanes": lanes}}})
+        )
+        return shared
+
+    def invoke(self, model_config, tmp_path, extra=()):
+        cluster = self.cluster_files(tmp_path, [CONDO, SPILL])
+        out = tmp_path / "out"
+        return runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--cluster-config",
+                str(cluster),
+                "--n-jobs-in-array",
+                "100",
+                "--script-only",
+                *extra,
+            ],
+        ), out
+
+    def test_one_json_line_per_lane(self, model_config, tmp_path):
+        result, out = self.invoke(model_config, tmp_path, ["--use-all-lanes"])
+        assert result.exit_code == 0, result.output
+        records = [
+            json.loads(ln) for ln in result.output.splitlines() if ln.startswith("{")
+        ]
+        assert len(records) == 2
+        assert [r["account"] for r in records] == ["my-condo", "default"]
+        assert sum(r["array_size"] for r in records) == 100
+        assert {r["n_lanes"] for r in records} == {2}
+        # distinct scripts, distinct array sizes in the emitted sbatch headers
+        scripts = sorted((out / "runs").glob("*.sh"))
+        assert len(scripts) == 2
+        arrays = sorted(
+            line
+            for script in scripts
+            for line in script.read_text().splitlines()
+            if line.startswith("#SBATCH --array")
+        )
+        assert arrays == ["#SBATCH --array=1-23", "#SBATCH --array=1-77"]
+
+    def test_without_the_flag_it_stays_single_lane(self, model_config, tmp_path):
+        """Fan-out must be opt-in: it changes how many jobs land on the cluster."""
+        result, out = self.invoke(model_config, tmp_path)
+        assert result.exit_code == 0, result.output
+        records = [
+            json.loads(ln) for ln in result.output.splitlines() if ln.startswith("{")
+        ]
+        assert len(records) == 1
+        assert records[0]["account"] == "lab-condo"
+        assert records[0]["array_size"] == 100
+        assert records[0]["n_lanes"] == 1
+        assert len(list((out / "runs").glob("*.sh"))) == 1
+
+    def test_worker_run_names_do_not_collide_across_lanes(
+        self, model_config, tmp_path, fake_sbatch_ok, isolated_mlflow
+    ):
+        """Both arrays number tasks from 1, so the lane must enter the name."""
+        cluster = self.cluster_files(tmp_path, [CONDO, SPILL])
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--cluster-config",
+                str(cluster),
+                "--n-jobs-in-array",
+                "10",
+                "--use-all-lanes",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        names = [
+            ln.split("--mlflow-run-name ")[1].split(" --")[0]
+            for ln in result.output.splitlines()
+            if "--mlflow-run-name" in ln
+        ]
+        assert len(names) == 2 and names[0] != names[1], names
+
+    def test_a_failed_lane_makes_the_whole_submission_fail(
+        self, model_config, tmp_path, fake_sbatch_fail, isolated_mlflow
+    ):
+        """Partial success is failure: some lanes run, some do not, and only
+        the JSON lines say which."""
+        cluster = self.cluster_files(tmp_path, [CONDO, SPILL])
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(tmp_path / "out"),
+                "--cluster-config",
+                str(cluster),
+                "--n-jobs-in-array",
+                "10",
+                "--use-all-lanes",
+            ],
+        )
+        assert result.exit_code == 1
+        records = [
+            json.loads(ln) for ln in result.output.splitlines() if ln.startswith("{")
+        ]
+        assert len(records) == 2
+        assert all(r["job_id"] is None for r in records)


### PR DESCRIPTION
**Stacked on #28** — review the top commit only; retarget to `main` once #28 merges.

## The finding that motivates it

A second lane really does exist, but not the one we expected:

| account | partition | QOS | priority | per-user cap |
|---|---|---|---|---|
| `<condo>` | batch | condo QOS | **10000** | **208 cores** |
| `<condo>` | gpu-he | condo GPU QOS | 10000 | 160 cores, 75 GPUs |
| `default` | batch | `normal` | **0** | **64 cores** |
| `default` | gpu | `norm-gpu` | 0 | 12 cores, 2 GPUs |

The personal account is **64 cores, not ~208**, and it is **priority 0, not high priority** — it is the general CCV allocation. Still worth having: `MaxTRESPU` is enforced *per QOS*, so the lanes are independent budgets and **208 + 64 = 272 cores, ≈ +31%** for datagen.

Honest caveat, stated in the docs too: at the time of writing `batch` was 119 allocated / 133 mixed / 7 idle, so priority-0 work queues behind everyone else. This is **opportunistic** capacity — good for an overnight sweep, unreliable against a deadline.

## What lands

**1. `scripts/discover_cluster.py`** — asks SLURM what *this* user holds and writes the gitignored `configs/cluster/oscar.local.yaml`. Runs on a login node, or from a laptop with `--ssh-host oscar`. It also proposes a `job_defaults` mapping: every CPU lane for datagen, one GPU on the best GPU lane for training.

Why discovery rather than documentation: the deciding numbers are `MaxTRESPU` on the **QOS**, and `scontrol show partition` reports `MaxTime=UNLIMITED` for every partition here — reading partition limits tells you nothing.

**2. Config layering.** `<name>.local.yaml` is merged over `<name>.yaml` automatically, so precedence is `builtin < shared < personal < CLI`. This is the same split #28 just adopted for paths, applied to allocations — the repo keeps lab facts, the gitignored file keeps yours.

**3. `--use-all-lanes`.** Splits an array across lanes proportional to core caps and emits one JSON line per lane:

```json
{"lane": 0, "n_lanes": 2, "account": "<condo>", "array_size": 77, "job_id": 9876543, ...}
{"lane": 1, "n_lanes": 2, "account": "default", "array_size": 23, "job_id": 9876544, ...}
```

Opt-in, because it changes how many jobs land on the cluster. A single-lane run still emits exactly one line with `lane: 0, n_lanes: 1`, so the driver contract is **extended, not broken** (three additive keys).

## Details that would have been bugs

- **Both arrays number tasks from 1**, so without the lane index in the MLflow run name, worker runs collide across lanes. The lane is spliced into the name; a test asserts the two differ.
- **Partial submission is failure.** If one lane submits and another does not, the command exits non-zero and the JSON lines say which landed.
- **`debug`, `gpu-debug` and `vnc` are excluded** from lane discovery. They exist on every account and would otherwise inflate the totals — `vnc` was initially counted as a compute lane.
- **Training is not fanned out.** One job cannot use two lanes; discovery maps it to one GPU on the best GPU lane instead.

## Tests

73 pass (up from 54). New coverage: proportional split, every task allocated exactly once across many array sizes, priority ordering regardless of input order, single-task and capless-lane edge cases, local-over-shared merge precedence, one-JSON-line-per-lane with matching `#SBATCH --array` headers, opt-in behaviour, run-name collision, and partial-failure exit code.

```
uv run pytest tests/ -q                      # 73 passed
uv run ruff check . && uv run ruff format --check .
uv run python scripts/discover_cluster.py --ssh-host oscar --print   # verified live
```

## Not in this PR

The guided **questionnaire** — a spine `cluster-` skill that walks a new user through discovery, shows the lanes found, asks which to use per step, and writes the local config. That belongs in HSSMSpine, and this PR is the machinery it will drive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)