### PR TITLE
A notebook for looking at a candidate network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ cython_debug/
 # Per-user cluster lanes written by scripts/discover_cluster.py.
 # Personal allocations and paths never belong in the repo.
 configs/cluster/*.local.yaml
+
+# marimo scratch output
+__marimo__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,13 @@ validate = [
     # is what actually pulls the pair back into a working combination.
     "numba>=0.66",
 ]
+# Eyeballing a candidate network (validation/inspect_network.py). Separate from
+# `validate`: the gate must run headless on any machine, this only runs where a
+# human is looking. lanfactory already carries matplotlib/plotly/seaborn.
+inspect = [
+    "marimo>=0.11",
+    "onnxruntime>=1.17",
+]
 dev = [
     "pytest>=8.3.1",
     # <0.16: ruff 0.16 flags pre-existing code repo-wide (B008 on the standard

--- a/uv.lock
+++ b/uv.lock
@@ -532,6 +532,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docutils"
+version = "0.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/a4/5180d9afc57e8fca05601dd652bdff19604c218814037fe90ffc7625a50a/docutils-0.23.tar.gz", hash = "sha256:746f5060322511280a1e50eb76846ed6bf2342984b2ac04dc42caa1a8d78799e", size = 2303823, upload-time = "2026-05-27T17:41:06.934Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/91/30151a39f7570f448ed84529390628a651d7f27c87d73c9b887f8189695e/docutils-0.23-py3-none-any.whl", hash = "sha256:25d013af9bf23bc1c7b2b093dff4208166c53a94786c9e447808335ef1185fea", size = 634701, upload-time = "2026-05-27T17:40:58.442Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,6 +1138,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1193,6 +1214,10 @@ dev = [
     { name = "pytest" },
     { name = "ruff" },
 ]
+inspect = [
+    { name = "marimo" },
+    { name = "onnxruntime" },
+]
 validate = [
     { name = "hssm" },
     { name = "numba" },
@@ -1212,6 +1237,10 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.1" },
     { name = "ruff", specifier = ">=0.15.1,<0.16" },
+]
+inspect = [
+    { name = "marimo", specifier = ">=0.11" },
+    { name = "onnxruntime", specifier = ">=1.17" },
 ]
 validate = [
     { name = "hssm", specifier = ">=0.4.0" },
@@ -1265,6 +1294,28 @@ wheels = [
 ]
 
 [[package]]
+name = "loro"
+version = "1.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6e/527f6b403a70689bd304d0cb35765601a0162727ce80299b47e9b7597390/loro-1.13.2.tar.gz", hash = "sha256:7a44db450beec71cfa12192dd11cc327e370c920fce60d48f20c871c1e33d809", size = 70471, upload-time = "2026-07-21T13:48:04.385Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/b2/13bcf108d5bd52ea1835cd69450bca37f87fae656c6b3f130d6bf874e855/loro-1.13.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a4723ca5f416a00b1b0b896c1aaaef89629e52a05879c42087a1a6887afa7370", size = 3296091, upload-time = "2026-07-21T13:44:59.842Z" },
+    { url = "https://files.pythonhosted.org/packages/27/30/c85fa1cd0bb755f127d6c04a01167a41f3b6380c47f97426169964a75149/loro-1.13.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f1e7d57ddc92a890fc8fe314b4e769d5492cd9fca0931f9be78d49eba66ac69", size = 3155585, upload-time = "2026-07-21T13:44:39.613Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/25/dd29d0a810f87d73c5fbfd4d915a23deead58349c7659e31a0e95a7ff8ec/loro-1.13.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5773c88a7cf828e487c494f7329d82382c044695831f9fb5715c39ebc42cd8d", size = 3492899, upload-time = "2026-07-21T13:41:02.284Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f3/cf6263d4933410aff9f0a79a5537abc6c882928e4cf012e24ff49207eeba/loro-1.13.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0054ffc1c8c5a3b8d2e38ac7d2ffc63618f48c13b10c7a0481ec4e16fb02352d", size = 3535389, upload-time = "2026-07-21T13:41:44.66Z" },
+    { url = "https://files.pythonhosted.org/packages/24/45/6d252e007dd86372dd9b49f527abbfd30ba9b383013f970cf9f599003271/loro-1.13.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e330da10672e8a8b4f914a00f96ab9516ea6c9a51956d04d9aaed5ae399382f9", size = 3936005, upload-time = "2026-07-21T13:42:22.466Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/41/568689a5416da2849ae58faa55ed23f2e909bd1bbd836301d5006b67ad3f/loro-1.13.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:edc55f83886a805f16e68e05cfe55c9929f571fda5e713eb01ca56b44d129a4c", size = 3608544, upload-time = "2026-07-21T13:43:00.898Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d7/8989db26652feca4553657b3511ebfe3af32c784fac3971a42e3cfd830e0/loro-1.13.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c93c84b32d50521d249b6738be7a4bf590aa35b03efce7cf7606e2ff5925ebe", size = 3453408, upload-time = "2026-07-21T13:44:10.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/d818ec6b7bb45c61e8ffe47cd1f26fd815b0ba4282b6c9236d04bdc4e1db/loro-1.13.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a53eb55f6093b07d40ea9f195d80001e6c660a32accc83e5652a365b7a8645dd", size = 3835038, upload-time = "2026-07-21T13:43:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/7d/623bdeeea11d5a4d856c336689024de78dda354e5d6ca922785ec50b96b8/loro-1.13.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8ca0da06d5a5fbf5c444c8701753a7a661a6caf4aa6ed0c4b088c0e47c0834f1", size = 3667368, upload-time = "2026-07-21T13:45:20.213Z" },
+    { url = "https://files.pythonhosted.org/packages/02/53/ccc350828bb345b1303d6eca0d7d06a847848560ba0a731b0406c54c6914/loro-1.13.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0bc0f4632b211b7c08d48d5962ca83281ae940ba5c99693bd924a272878d7915", size = 3807506, upload-time = "2026-07-21T13:46:01.605Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/93/f9bb444c223d548f1eb6103d39fb9fee491190156fcdb2a5a8d538e0dc0d/loro-1.13.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5a508baf31a08c210425c364fe2a6ab93ae10ce10eb7660d84e372af1e086457", size = 3859411, upload-time = "2026-07-21T13:46:43.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a5/d5ed51792319677750ad296b39b924387c9061ff7f5e4755131976d67bc3/loro-1.13.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c3741fb0e5d2ed74c2a2d694a0c025bb5b93032eb3fe4ad8561133decccb0477", size = 3771552, upload-time = "2026-07-21T13:47:26.366Z" },
+    { url = "https://files.pythonhosted.org/packages/be/33/03a58d87d11527eb65d90e098bc99486e0d449cb7e7daafe7434ec254dd6/loro-1.13.2-cp312-cp312-win32.whl", hash = "sha256:457701289e7f7f8e99d76a34b75c528b0bee25c4882c7309801aabbfbdbb7621", size = 2849205, upload-time = "2026-07-21T13:48:30.22Z" },
+    { url = "https://files.pythonhosted.org/packages/af/17/9f171e79698fec0c60686ebda29f41504fc2bbaa628db931dcb00f0f7218/loro-1.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:523a319879b42a454e9f2376280a8db131c03236d9fcc56295a40adf95f2980b", size = 3093182, upload-time = "2026-07-21T13:48:08.759Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1274,6 +1325,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
+name = "marimo"
+version = "0.23.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click", marker = "sys_platform != 'emscripten'" },
+    { name = "docutils" },
+    { name = "itsdangerous" },
+    { name = "jedi" },
+    { name = "loro", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
+    { name = "markdown" },
+    { name = "msgspec" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "psutil", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "pyzmq", marker = "sys_platform != 'emscripten'" },
+    { name = "starlette", marker = "sys_platform != 'emscripten'" },
+    { name = "tomlkit" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "websockets", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/c0/b6b7101dc9d3760c51d67714d4547047cb2c29c11f26691bed6a64d8a995/marimo-0.23.16.tar.gz", hash = "sha256:378c892f0e1bc3985bc0b5b61109078e09fc767438b95234bfec9faa45858c98", size = 38789959, upload-time = "2026-07-31T20:04:47.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/7a/db0583b21d1f03403fc26800cb4638f59e95a33efd333f7a4d45ac348b82/marimo-0.23.16-py3-none-any.whl", hash = "sha256:e0bba0a44b395d402072c65d686fb459bd8955c9ab8b0d6135a22f729c989373", size = 39241287, upload-time = "2026-07-31T20:04:43.678Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
 ]
 
 [[package]]
@@ -1477,6 +1567,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
     { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
     { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+]
+
+[[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
 ]
 
 [[package]]
@@ -1981,6 +2087,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "pathos"
 version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2242,6 +2357,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2309,6 +2437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.3.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -2343,6 +2480,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
 ]
 
 [[package]]
@@ -2653,6 +2811,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
 name = "toolz"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2862,6 +3029,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "17.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/96/e01084f83a64bcb3a27994bd0cb0db68ff29d9c6707fae37ec19b18ba990/websockets-17.0.1.tar.gz", hash = "sha256:5baa9bc0dfbae8c507e51c8cf1b6d4628086f7a87bbd3a9952bd5f035451f1cc", size = 183298, upload-time = "2026-07-31T11:31:27.665Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/ff/6199a52d864215750af8668d84b0274775011a90052081f5a9495807a92b/websockets-17.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:10f461191125c63902ea7394ae9e752b1b5785641850c1d365bb30b0f88bc53f", size = 212603, upload-time = "2026-07-31T11:29:30.771Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7e/439a962bcada88dcf586da77a1b2385f91e2d2910e9359540934c827156b/websockets-17.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cffc84ddec6da7f447677266fee2a3c40ecc78172f00752aa1150b8a8d65df1d", size = 210286, upload-time = "2026-07-31T11:29:32.157Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/123660edc759c225626b3b91952c7625f85c77a8362acbc35a4623120f7d/websockets-17.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c23e532c8a2325a1e7486de8763a60dc43e83f01bcaeca07e3ba79652c156db1", size = 210549, upload-time = "2026-07-31T11:29:33.388Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2f/2940e57080cf56f28190287516400126d5a76b52b9a61dc10ba6f6400dbe/websockets-17.0.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c09e097d0e46e3c289bedab9a475ae344b70c30ff5646e46af22b4e6fdc97b21", size = 219874, upload-time = "2026-07-31T11:29:34.608Z" },
+    { url = "https://files.pythonhosted.org/packages/42/28/9ec976c16d63cc51c28dfec74b66854048c0b8b6579946e902f91b69e8bf/websockets-17.0.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f47b0815af3948ec6a440b3afa02f05b18cc0939549e91b5c677b5d9c2c8472a", size = 220150, upload-time = "2026-07-31T11:29:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a4/850c699a16bbc451723856360c59bd997bec075e637154f3fa96e80d5760/websockets-17.0.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8848c207049ad49d318e5f64a3d4d7bb189f8328d0d98e65647788f2a085785c", size = 221389, upload-time = "2026-07-31T11:29:37.189Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e1/f60a891c1a4b3420d5052333a84eb7241e1fb4a71866dec1562f5fa30027/websockets-17.0.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2604de7228506b13a44a256a9d223943340c0e725af5d367dc068e192b027761", size = 224169, upload-time = "2026-07-31T11:29:38.61Z" },
+    { url = "https://files.pythonhosted.org/packages/26/fb/e2a893be6fae4fddfe50ddc3035a331d3f381103d5467b7900026bdb3a64/websockets-17.0.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07abc3bd196a48af476a82fd47f3f79a6a3f70937a9f930cef703cfa0c9d83b6", size = 222025, upload-time = "2026-07-31T11:29:39.897Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/72/e3144b2d79276fab9798ed7d4aea2f0847434f186800b6f56a1eddcb3114/websockets-17.0.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:769ce7e2acfd9a89f2bed3a9c0da229459516bbc00bd4c9e2ca492c613ae4861", size = 220779, upload-time = "2026-07-31T11:29:41.084Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/5e/69c02174fbcf1c40c6adc45d3c316a401558392fe7bab8969ef8c46f1689/websockets-17.0.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07d78a509c3333f5908c83d7f78144ea68a6c9ec28110f5c54d81d8fcdc262c4", size = 218053, upload-time = "2026-07-31T11:29:42.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/09/7574778b095b99cfa0856583462f56568df784f9b41485145169b2ec9c64/websockets-17.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ffad64ce7ad3703d652a3fd9af26238377d24ce52c6ad8ff35d26d82f61f493f", size = 220825, upload-time = "2026-07-31T11:29:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e6/f46571f38765dbc4cbc0d0b47de8db65768006dbbd4340e6f5f51bc1d895/websockets-17.0.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e95e321d0d763f2b6633512605f6112ebd70d5746f3ce05c941909d4a25233f2", size = 219427, upload-time = "2026-07-31T11:29:44.731Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/6ff1fee057bd7e9dd5237fc064a749615378d003aa045b5bfc2d12b2f4f7/websockets-17.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cd526c8228e759c1006c4b7c9ac71dc4e925ced1a6a6a5a8e94643709738f63e", size = 220198, upload-time = "2026-07-31T11:29:45.997Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/4f/d41847227a44b9ad87c3d5a9fddbfad8b7c4d6032878d8460d9d37c2d44f/websockets-17.0.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8cd3369e42c0246afaf9d669cfc19797e3a49e8c0a639544459c57597108b966", size = 221304, upload-time = "2026-07-31T11:29:47.314Z" },
+    { url = "https://files.pythonhosted.org/packages/63/30/21a7e326c6ad2eb526cd5b816383d59cdeb28b8805b65a543c3cfbd8e8ce/websockets-17.0.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:b580794e926cab7ff42ee4371ef14e0b22cb2bb722a607f77769136468f49a3f", size = 218858, upload-time = "2026-07-31T11:29:48.587Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/48/55b0331cd5bec9ce29748f79edc00075805450a47011d0c8e3b1c61dbf04/websockets-17.0.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5033ffe6804dd53afafa7d08e8c3eef2d2431f34d58ca30507a8442dd04a033a", size = 219840, upload-time = "2026-07-31T11:29:49.791Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6e/2e8bc06e546f49b32a58a2bc2957902d1809ecc37552d3d7ccd6639a126e/websockets-17.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6db9e5bf3649ab506c6ae8a3ac85a00fb1ae3816d75962771b2df8adbc5d40d2", size = 220116, upload-time = "2026-07-31T11:29:51.026Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ad/4bac01fa41aca54307157b9c9f68b066a6bb51fb18716ba618078a67b283/websockets-17.0.1-cp312-cp312-win32.whl", hash = "sha256:bc0bca48ba24c6c866847fd20478a51dd547fa0ad258dab9615c414ec534bbc0", size = 213050, upload-time = "2026-07-31T11:29:52.328Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d8/c3a78cccc74a554780e9e76e323d5cde891048627025f0f82623e22dc3df/websockets-17.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:2b3f3020171202b135ca078e20434977c6b2b02af647130d6980c9e39b9462e3", size = 213348, upload-time = "2026-07-31T11:29:53.891Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/25/e1b8824bd632c8a5a62d504b61e9e35e470b67e4be0206f5c28f90c7f86d/websockets-17.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:41d6aa06b5ab832aee72fedf47a149535b121ac900b6bb4d3fe14712afac9a79", size = 213276, upload-time = "2026-07-31T11:29:55.299Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ce/3929538b2b9918f5eee623fbf3346893973191f6df93f19bbda097bd7bb7/websockets-17.0.1-py3-none-any.whl", hash = "sha256:c6be9cba65c65cc76dfa3d4619e359ff02a4476c74e179b215236c11a0b32345", size = 206718, upload-time = "2026-07-31T11:31:26.037Z" },
 ]
 
 [[package]]

--- a/validation/inspect_network.py
+++ b/validation/inspect_network.py
@@ -64,7 +64,20 @@ def _(mo):
     import os
     from pathlib import Path
 
-    onnx_path = Path(os.environ["INSPECT_ONNX"]).expanduser()
+    # The notebook's entire input is this one variable, so say so rather than
+    # letting a bare KeyError land in the cell output of a human-facing tool.
+    _onnx_env = os.environ.get("INSPECT_ONNX")
+    if not _onnx_env:
+        raise RuntimeError(
+            "Set INSPECT_ONNX to the artifact to inspect, then reopen:\n"
+            "    export INSPECT_ONNX=/path/to/..._model.onnx\n"
+            "    export INSPECT_MODEL=ddm_sdv   # optional, defaults to ddm"
+        )
+    onnx_path = Path(_onnx_env).expanduser()
+    if not onnx_path.is_file():
+        # Caught here rather than in the onnxruntime cell below, so the cells
+        # in between do not render a confident header for a file that is absent.
+        raise FileNotFoundError(f"INSPECT_ONNX does not exist: {onnx_path}")
     model_name = os.environ.get("INSPECT_MODEL", "ddm")
 
     # The gate writes this next to the artifact when it runs. Optional: the
@@ -155,16 +168,21 @@ def _(lower, mo, np, param_names, upper):
     # failures that say nothing about ordinary use. Same 10% the gate uses.
     _shrink = 0.1
     _span = upper - lower
-    _lo, _hi = lower + _shrink * _span, upper - _shrink * _span
+    # Not underscore-prefixed like the rest: marimo keeps `_`-names cell-local,
+    # and the manifold sweep below has to land inside the same box these draws
+    # come from.
+    lo_shrunk, hi_shrunk = lower + _shrink * _span, upper - _shrink * _span
 
     _rng = np.random.default_rng(0)
     n_parameter_sets = 3
     parameter_df = pd.DataFrame(
-        _lo + (_hi - _lo) * _rng.uniform(size=(n_parameter_sets, len(param_names))),
+        lo_shrunk
+        + (hi_shrunk - lo_shrunk)
+        * _rng.uniform(size=(n_parameter_sets, len(param_names))),
         columns=param_names,
     )
     mo.ui.table(parameter_df.round(3), label="Parameter vectors under inspection")
-    return parameter_df, pd
+    return hi_shrunk, lo_shrunk, parameter_df, pd
 
 
 @app.cell
@@ -201,16 +219,29 @@ def _(mo):
 
 
 @app.cell
-def _(model_name, np, param_names, parameter_df, predict_on_batch):
+def _(
+    hi_shrunk,
+    lo_shrunk,
+    model_name,
+    np,
+    param_names,
+    parameter_df,
+    predict_on_batch,
+):
     from lanfactory.network_inspectors import lan_manifold
 
     # Sweep drift where the model has it, otherwise the first parameter, so
-    # this cell does not assume a particular model's parameterisation.
+    # this cell does not assume a particular model's parameterisation — and
+    # sweep it across its own trained range rather than a fixed window. The
+    # models without a `v` lead with a strictly positive parameter (race `v0`,
+    # lba `A`, poisson_race `r1`), where a hardcoded -1.5..1.5 is mostly
+    # domain the network was never shown.
     _sweep = "v" if "v" in param_names else param_names[0]
+    _i = param_names.index(_sweep)
 
     lan_manifold(
         parameter_df=parameter_df,
-        vary_dict={_sweep: list(np.linspace(-1.5, 1.5, 9))},
+        vary_dict={_sweep: list(np.linspace(lo_shrunk[_i], hi_shrunk[_i], 9))},
         model=model_name,
         torch_mlp_predict=predict_on_batch,
     )

--- a/validation/inspect_network.py
+++ b/validation/inspect_network.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Look at a candidate network before trusting the gate's verdict.
+
+`validate_network.py` returns numbers. This is the human counterpart: it puts
+the network's implied density next to kernel density estimates from the
+simulator it is meant to approximate, so "reasonable" is something you can see
+rather than infer from a Hellinger ratio.
+
+Run it against any artifact:
+
+    export INSPECT_ONNX=/path/to/..._model.onnx
+    export INSPECT_MODEL=ddm_sdv
+    uv run --group inspect marimo edit validation/inspect_network.py
+
+or render it without a browser:
+
+    uv run --group inspect marimo export html validation/inspect_network.py \\
+        -o inspection.html
+
+The predictor adapter is the only non-obvious part. lanfactory's inspectors
+were written against the torch backend and call the network with a whole
+(n_grid, n_params + 2) batch; ecosystem ONNX artifacts take exactly one trial
+per call by contract, so the adapter loops. It is the same asymmetry the
+parity gate has to live with.
+"""
+
+import marimo
+
+__generated_with = "0.11.0"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # Does this network look like the simulator?
+
+        Two views, both from `lanfactory.network_inspectors`:
+
+        1. **KDE vs LAN** — the network's likelihood over an RT grid, drawn on
+           top of repeated kernel density estimates from actual simulations at
+           the same parameters. A usable network traces the KDE cloud. An
+           untrained one wanders off it, and you can see exactly where.
+        2. **Manifold** — the same likelihood swept across one parameter. A
+           trained network deforms smoothly; an untrained one is lumpy or flat.
+
+        Neither replaces the gate. They explain *what* the gate objected to.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    import json
+    import os
+    from pathlib import Path
+
+    onnx_path = Path(os.environ["INSPECT_ONNX"]).expanduser()
+    model_name = os.environ.get("INSPECT_MODEL", "ddm")
+
+    # The gate writes this next to the artifact when it runs. Optional: the
+    # notebook is useful on a network that was never gated.
+    report_path = onnx_path.parent / "validation_report.json"
+    report = json.loads(report_path.read_text()) if report_path.exists() else None
+
+    mo.md(f"""
+    **Artifact** `{onnx_path.name}`
+    **Model** `{model_name}`
+    **Gate report** {"found" if report else "not found — showing plots only"}
+    """)
+    return json, model_name, onnx_path, report
+
+
+@app.cell
+def _(mo, report):
+    def _verdict_table(report):
+        if not report:
+            return mo.md("_No gate report alongside this artifact._")
+        rows = []
+        for gate in report["gates"]:
+            scores = {
+                k: v
+                for k, v in gate.items()
+                if k
+                in (
+                    "max_abs_error",
+                    "initial_logp",
+                    "worst_ratio",
+                    "worst_total_mass",
+                    "input_shape",
+                )
+            }
+            mark = (
+                "skipped"
+                if gate.get("skipped")
+                else ("pass" if gate["passed"] else "FAIL")
+            )
+            detail = ", ".join(f"`{k}`={v}" for k, v in scores.items())
+            rows.append(f"| {gate['gate']} | {mark} | {detail} |")
+        return mo.md("| gate | verdict | scores |\n|---|---|---|\n" + "\n".join(rows))
+
+    _verdict_table(report)
+    return
+
+
+@app.cell
+def _(model_name, onnx_path):
+    import numpy as np
+    import onnxruntime as ort
+
+    _session = ort.InferenceSession(str(onnx_path))
+    _input_name = _session.get_inputs()[0].name
+
+    def predict_on_batch(batch):
+        """Adapt a single-trial ONNX to the inspectors' batch predictor.
+
+        The ecosystem contract fixes the graph's batch dimension at 1 — a
+        stacked feed is rejected by onnxruntime outright — so the batch is
+        evaluated row by row and restacked as (n, 1), which is what
+        `evaluate_network` indexes with `[:, 0]`.
+        """
+        rows = np.asarray(batch, dtype=np.float32)
+        return np.stack(
+            [
+                np.asarray(
+                    _session.run(None, {_input_name: rows[i : i + 1]})[0]
+                ).reshape(-1)
+                for i in range(rows.shape[0])
+            ]
+        )
+
+    import ssms
+
+    _config = ssms.config.model_config[model_name]
+    param_names = list(_config["params"])
+    lower, upper = (np.asarray(b, dtype=float) for b in _config["param_bounds"])
+    return lower, np, param_names, predict_on_batch, upper
+
+
+@app.cell
+def _(lower, mo, np, param_names, upper):
+    import pandas as pd
+
+    # Away from the edges: a network is not expected to be accurate at the very
+    # boundary of the space it was trained on, and testing there produces
+    # failures that say nothing about ordinary use. Same 10% the gate uses.
+    _shrink = 0.1
+    _span = upper - lower
+    _lo, _hi = lower + _shrink * _span, upper - _shrink * _span
+
+    _rng = np.random.default_rng(0)
+    n_parameter_sets = 3
+    parameter_df = pd.DataFrame(
+        _lo + (_hi - _lo) * _rng.uniform(size=(n_parameter_sets, len(param_names))),
+        columns=param_names,
+    )
+    mo.ui.table(parameter_df.round(3), label="Parameter vectors under inspection")
+    return parameter_df, pd
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 1. Network likelihood vs simulated KDEs""")
+    return
+
+
+@app.cell
+def _(model_name, parameter_df, predict_on_batch):
+    from lanfactory.network_inspectors import kde_vs_lan_likelihoods
+
+    kde_vs_lan_likelihoods(
+        parameter_df=parameter_df,
+        model=model_name,
+        torch_mlp_predict=predict_on_batch,
+        n_samples=2000,
+        n_reps=5,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2. Likelihood manifold across a swept parameter
+
+        Drift is the parameter whose effect is easiest to read: raising it
+        should move mass toward one choice and sharpen the RT peak.
+        """
+    )
+    return
+
+
+@app.cell
+def _(model_name, np, param_names, parameter_df, predict_on_batch):
+    from lanfactory.network_inspectors import lan_manifold
+
+    # Sweep drift where the model has it, otherwise the first parameter, so
+    # this cell does not assume a particular model's parameterisation.
+    _sweep = "v" if "v" in param_names else param_names[0]
+
+    lan_manifold(
+        parameter_df=parameter_df,
+        vary_dict={_sweep: list(np.linspace(-1.5, 1.5, 9))},
+        model=model_name,
+        torch_mlp_predict=predict_on_batch,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ---
+        **Reading these.** A network worth publishing sits inside the spread of
+        the KDE replicates — the replicates themselves disagree, and that
+        disagreement is the noise floor the gate calibrates against. A network
+        that is above, below, or the wrong shape is not close; no amount of
+        threshold tuning fixes it, and the gate's `worst_ratio` is measuring
+        exactly this gap.
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/validation/inspect_network.py
+++ b/validation/inspect_network.py
@@ -85,10 +85,26 @@ def _(mo):
     report_path = onnx_path.parent / "validation_report.json"
     report = json.loads(report_path.read_text()) if report_path.exists() else None
 
+    # The report is directory-scoped but the artifact is not, and LANfactory
+    # writes every run of a model into one flat folder — so the report sitting
+    # here may well describe a different network. Rendering its verdict under
+    # this artifact's name would be the worst kind of wrong. Matched on
+    # filename rather than full path: the names carry the run_uuid, and a
+    # report fetched from the cluster records the path it was gated at there.
+    _describes = Path(report.get("onnx", "")).name if report else None
+    report_note = "not found — showing plots only"
+    if report and _describes != onnx_path.name:
+        report_note = (
+            f"**ignored — it describes `{_describes or 'an unnamed artifact'}`**"
+        )
+        report = None
+    elif report:
+        report_note = "found"
+
     mo.md(f"""
     **Artifact** `{onnx_path.name}`
     **Model** `{model_name}`
-    **Gate report** {"found" if report else "not found — showing plots only"}
+    **Gate report** {report_note}
     """)
     return json, model_name, onnx_path, report
 
@@ -97,7 +113,7 @@ def _(mo):
 def _(mo, report):
     def _verdict_table(report):
         if not report:
-            return mo.md("_No gate report alongside this artifact._")
+            return mo.md("_No gate report for this artifact._")
         rows = []
         for gate in report["gates"]:
             scores = {
@@ -133,6 +149,17 @@ def _(model_name, onnx_path):
     _session = ort.InferenceSession(str(onnx_path))
     _input_name = _session.get_inputs()[0].name
 
+    # Checked once, here: everything below reads column zero of the first
+    # output, so a graph with a second output — or a wider one — would still
+    # plot, showing a slice of something that is not this network's
+    # log-density. A LAN returns exactly one value per trial.
+    if len(_session.get_outputs()) != 1:
+        raise ValueError(
+            f"{onnx_path.name} has {len(_session.get_outputs())} outputs; a "
+            "LAN has one log-density output. This is not a network these "
+            "plots can read."
+        )
+
     def predict_on_batch(batch):
         """Adapt a single-trial ONNX to the inspectors' batch predictor.
 
@@ -142,7 +169,7 @@ def _(model_name, onnx_path):
         `evaluate_network` indexes with `[:, 0]`.
         """
         rows = np.asarray(batch, dtype=np.float32)
-        return np.stack(
+        out = np.stack(
             [
                 np.asarray(
                     _session.run(None, {_input_name: rows[i : i + 1]})[0]
@@ -150,6 +177,13 @@ def _(model_name, onnx_path):
                 for i in range(rows.shape[0])
             ]
         )
+        if out.shape[1] != 1:
+            raise ValueError(
+                f"{onnx_path.name} returned {out.shape[1]} values per trial, "
+                "not one log-density. The plots index column zero and would "
+                "quietly show a slice of it."
+            )
+        return out
 
     import ssms
 


### PR DESCRIPTION
The gate answers *does this pass*. It does not answer *what is wrong with it* — and `worst_ratio 9.56` does not tell you whether the network missed the shape, the scale, or the choice split.

`validation/inspect_network.py` is the human counterpart: a marimo notebook that draws the network's likelihood on top of repeated KDEs from the simulator it approximates, plus a manifold sweep across one parameter.

Both plots come from **`lanfactory.network_inspectors`**, which already existed on LANfactory main and which nothing in this repo was calling.

## The adapter is the only non-obvious part

Those inspectors were written against the torch backend and call the network with a whole `(n_grid, n_params + 2)` batch. Ecosystem ONNX artifacts take exactly **one trial per call** by contract, and onnxruntime rejects a stacked feed outright, so `predict_on_batch` loops and restacks to `(n, 1)` — which is what `evaluate_network` indexes with `[:, 0]`.

Same asymmetry the parity gate lives with, and worth having written down in one more place.

## Details

- Parameterised by `INSPECT_ONNX` / `INSPECT_MODEL`, not hardcoded to anyone's paths.
- Reads `validation_report.json` when the gate left one beside the artifact, so the numbers and the picture sit together. Optional — it works on a network that was never gated.
- Parameter draws use the **same 10%-shrunk bounds as G4**, so the plots show what the gate actually scored rather than a different slice.
- Sweeps `v` where the model has it, otherwise the first parameter, so it does not assume a parameterisation.
- New `inspect` dependency group, separate from `validate`: the gate must run headless anywhere, this only runs where a human is looking. matplotlib/plotly/seaborn already come with lanfactory.

## Rendered against the M1 smoke ddm_sdv network

It gets the bimodal structure roughly right and the sharpness badly wrong — the KDE peaks at **6.2** where the network reaches **1.15**, and mass sits in the tails where the simulator has none.

That is what `worst_total_mass 2.59` and `worst_ratio 9.56` look like, and it is the expected result for 2 epochs on 4 files. The point is that the picture and the number agree.

`88 passed`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive inspection notebook for evaluating ONNX network quality against simulator distributions and likelihood manifolds.
  * Added visualizations for KDE comparisons, parameter-sweep manifolds, and validation gate results.
  * Added optional support for loading gate reports and inspecting bounded parameter samples.

* **Chores**
  * Added an inspection environment with the required analysis tools.
  * Excluded generated interactive notebook output from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->