### PR TITLE
Pass --n-cpus to the generate command

### DIFF
--- a/sbatch_scripts/gen_sbatch.py
+++ b/sbatch_scripts/gen_sbatch.py
@@ -766,6 +766,14 @@ def handle_job(
         )
         if command_name == "generate" and n_files is not None:
             params["n-files"] = n_files
+        if command_name == "generate":
+            # State the worker count instead of letting the generator infer it.
+            # Its "all" default reads sched_getaffinity, which is correct under
+            # SLURM but grabs the whole machine anywhere else — and either way
+            # the number never appears in the submission record. Passing the
+            # cores we actually requested keeps the two in step and puts the
+            # value in the generated script and the JSON line.
+            params["n-cpus"] = resources["cores"]
         command = create_command(command_name, **params)
         logger.info(f"Generated command: {command}")
 

--- a/tests/test_gen_sbatch.py
+++ b/tests/test_gen_sbatch.py
@@ -978,3 +978,53 @@ class TestUvResolution:
     def test_runs_through_the_resolved_uv(self):
         # Not a hardcoded `python -m uv run`, which is what broke.
         assert "$UV run {command}" in gen_sbatch.SBATCH_TEMPLATE
+
+
+class TestNCpusPassthrough:
+    """The generate command states its worker count instead of inferring it.
+
+    ssm-simulators defaults n_cpus to "all", which reads sched_getaffinity —
+    correct under SLURM, but it grabs the whole machine anywhere else, and
+    either way the number never reaches the submission record.
+    """
+
+    def test_n_cpus_matches_the_requested_cores(self, model_config, tmp_path):
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "generate",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--cores",
+                "12",
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = next((out / "runs").glob("*.sh")).read_text()
+        # The CLI value and the SBATCH directive must not drift apart.
+        assert "--n-cpus 12" in script
+        assert "#SBATCH -c 12" in script
+
+    def test_training_commands_do_not_get_n_cpus(self, model_config, tmp_path):
+        # jaxtrain/torchtrain have no such option; passing it would be an error.
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "jaxtrain",
+                "--config-path",
+                str(model_config),
+                "--output-path",
+                str(out),
+                "--training-data-folder",
+                str(tmp_path / "data"),
+                "--script-only",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        script = next((out / "runs").glob("*.sh")).read_text()
+        assert "--n-cpus" not in script

--- a/uv.lock
+++ b/uv.lock
@@ -2586,7 +2586,7 @@ wheels = [
 [[package]]
 name = "ssm-simulators"
 version = "0.13.2"
-source = { git = "https://github.com/lnccbrown/ssm-simulators?branch=main#ea96172b78b0cb2c14730b4b4f30f3e396424abe" }
+source = { git = "https://github.com/lnccbrown/ssm-simulators?branch=main#7f6f5c2cc75f551493b6a670a96e09fd4a850cb6" }
 dependencies = [
     { name = "cloudpickle" },
     { name = "matplotlib" },


### PR DESCRIPTION
`gen_sbatch` passes `--n-cpus {cores}` to the `generate` command, and the lockfile now points at an ssm-simulators that has that flag.

**Unblocked:** [ssm-simulators#326](https://github.com/lnccbrown/ssm-simulators/pull/326) is merged, so the lock moves `ea96172 → 7f6f5c2`. Targeted bump (`uv lock --upgrade-package ssm-simulators`), not a blanket `--upgrade` — that is how ruff 0.16 drift got in last time.

## What it fixes

The generator defaults `n_cpus` to `"all"`, resolved via `sched_getaffinity`. That is correct under SLURM but takes the whole machine anywhere else, and either way **the number never reached the submission record**. Answering *"how many cores is this 300-task array actually using"* meant sshing to a compute node and reading `ps`.

Passing the cores we already requested keeps the CLI value and the `#SBATCH -c` directive in step **by construction** — both come from the same `resources["cores"]`.

## Verified by hand, because CI cannot cover it

`local_test_run.sh` calls `uv run generate` **directly** and never goes through `gen_sbatch`, so this passthrough has no automated end-to-end coverage — its green checks prove only that the unit tests and an unrelated e2e job pass. I ran the emitted script's own command:

```
gen_sbatch --cores 3   →  "--n-cpus 3" in the generated script
                          "#SBATCH -c 3"
                       →  INFO Overriding n_cpus from CLI: 3
                       →  INFO Parameter-set generation will use 2 worker processes (n_cpus=3)
```

Two workers rather than three because [ssm-simulators#327](https://github.com/lnccbrown/ssm-simulators/pull/327) (`workers = n_cpus`, dropping the reserved core) is not merged yet. That is the expected number for current main.

## Scope

Only `generate`. `jaxtrain`/`torchtrain` have no such option and would error on it; there is a test for each direction.

`96 passed`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)