### PR TITLE
ci(docs): sync project-site link root

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -73,6 +73,26 @@ jobs:
       - name: Verify Pages output
         run: test -f site/index.html
 
+      # GitHub project sites are served below /<repository>/. Mount site/ at
+      # that path so Lychee can resolve Material's root-relative URLs against
+      # the current artifact instead of requiring an already-deployed site.
+      - name: Mount rendered site at Pages path
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          if [[ ! "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "Unsupported repository name: $GITHUB_REPOSITORY" >&2
+            exit 2
+          fi
+          docs_project="${GITHUB_REPOSITORY#*/}"
+          if [[ "$docs_project" == "." || "$docs_project" == ".." ]]; then
+            echo "Unsupported Pages project path: $docs_project" >&2
+            exit 2
+          fi
+          docs_link_root="$RUNNER_TEMP/docs-link-root"
+          mkdir -p -- "$docs_link_root"
+          ln -s -- "$GITHUB_WORKSPACE/site" "$docs_link_root/$docs_project"
+
       # Link-check rendered HTML so generated reference and notebook links are
       # covered. Schedules and manual dispatches remain in the caller workflow.
       - name: Check rendered links
@@ -81,7 +101,7 @@ jobs:
         with:
           args: >-
             --config '${{ github.workspace }}/.lychee.toml'
-            --root-dir '${{ github.workspace }}/site'
+            --root-dir '${{ runner.temp }}/docs-link-root'
             --no-progress
             '${{ github.workspace }}/site/**/*.html'
           fail: true


### PR DESCRIPTION
## Summary

- vendor the canonical reusable workflow from merged HSSMSpine PR #67
- mount the rendered site beneath the repository slug for manual and scheduled link checks
- keep the temporary mount outside site/ so the Pages artifact is unchanged

## Context

The first Pages deployment is live. Manual-main runs then found 29 false local-file failures because root-relative project URLs were resolved below site/LAN_pipeline_minimal. The merged canonical workflow creates the correct temporary host-root view before invoking Lychee.

Canonical Spine merge: 21a9b257852ea08fda90660b9cd1265a83956ca6
Workflow SHA-256: bbd8cdb9f6c168715b9706213301440ad960c9fe46ca40df9db1faefedd27ae5

## Verification

- byte comparison with the merged canonical workflow
- bash -n scripts/docs.sh
- strict locked docs-only build with uv 0.12.2 and Python 3.12
- actionlint 1.7.12 across both workflows
- pinned Lychee 0.24.2 reproduction: 1,330 links, 0 errors with the corrected mount
- git diff --check

After merge, a manual run on main will verify rendered links and perform the second artifact deployment.